### PR TITLE
Proposal: Nix development environment and package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ font.c
 build/
 compile_commands.json
 .clangd
+result*

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ This assumes you have [installed brew](https://docs.brew.sh/Installation)
 ```
 brew update && brew install -y git gcc make sdl2 libserialport
 ```
+### Install required packages dependencies with nix (OSX, Linux)
+
+If you have the nix package manager installed (https://nixos.org/download.html),
+a nix development shell will all needed dependencies is provided. Simply enter:
+
+``` sh
+nix-shell
+```
 ### Download source code (All)
 
 ```
@@ -103,3 +111,9 @@ The driver can be enabled with ```sudo raspi-config``` and selecting "Advanced o
 Please note that with some configurations (for example, composite video) this can lead to not getting video output at all. If that happens, you can delete the row ```dtoverlay=vc4-kms-v3d``` in bottom of /boot/config.txt.
 
 Further performance improvement can be achieved by not using X11 and running the program directly in framebuffer console, but this might require doing a custom build of SDL.
+
+### Bonus: quickly install m8c locally with nix
+
+``` sh
+nix-env -iA m8c-stable -f https://github.com/laamaa/m8c/archive/refs/heads/main.tar.gz
+```

--- a/README.md
+++ b/README.md
@@ -38,14 +38,6 @@ This assumes you have [installed brew](https://docs.brew.sh/Installation)
 ```
 brew update && brew install -y git gcc make sdl2 libserialport
 ```
-### Install required packages dependencies with nix (OSX, Linux)
-
-If you have the nix package manager installed (https://nixos.org/download.html),
-a nix development shell will all needed dependencies is provided. Simply enter:
-
-``` sh
-nix-shell
-```
 ### Download source code (All)
 
 ```

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,34 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+let m8c-package =
+  { stdenv
+  , gnumake
+  , SDL2
+  , libserialport
+  , fetchFromGitHub
+  }:
+
+  let
+    pname = "m8c";
+    version = "1.0.3";
+  in
+    stdenv.mkDerivation {
+      inherit pname version;
+
+      src = fetchFromGitHub {
+        owner = "laamaa";
+        repo = pname;
+        rev = "v${version}";
+        hash = "sha256:0yrd6lnb2chgafhw1cz4awx2s1sws6mch5irvgyddgnsa8ishcr5";
+      };
+
+      installFlags = [ "PREFIX=$(out)" ];
+      nativeBuildInputs = [ gnumake ];
+      buildInputs = [ SDL2 libserialport ];
+    };
+in {
+  m8c-stable = pkgs.callPackage m8c-package {};
+  m8c-dev = (pkgs.callPackage m8c-package {}).overrideAttrs (oldAttrs: {src = ./.;});
+}

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,18 @@
 
 with pkgs;
 
+# HOWTO keep this package definition up-to-date:
+#
+# 1. NEW VERSION:
+# After the new version is tagged and pushed, update the `version` var to the
+# proper value and update the hash. You can use the following command to find
+# out the sha256, for example, with version 1.0.3:
+# `nix-prefetch-github --rev v1.0.3 laamaa m8c`
+#
+# 2. NEW DEPENDENCIES:
+# Make sure new dependencies are added. Runtime deps go to buildInputs and
+# compile-time deps go to nativeBuildInputs. Use the nixpkgs manual for help
+#
 let m8c-package =
   { stdenv
   , gnumake

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+mkShell {
+  inputsFrom = [ (import ./default.nix {}).m8c-dev ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -3,5 +3,6 @@
 with pkgs;
 
 mkShell {
+  packages = with pkgs; [ nix-prefetch-github ];
   inputsFrom = [ (import ./default.nix {}).m8c-dev ];
 }


### PR DESCRIPTION
(I'm opening this MR mostly as a discussion, and although I'd like to see some of these changes pulled upstream, it is in no way blocking anyone from working with the current project as it is. No pressure)

Adding two files:

- `shell.nix` provides a shell environment for development. In the project
  directory, entering the development shell by invoking `nix-shell` will pull
  all required dependencies to build the project (based on the latest stable
  release).
- `default.nix` provides a package description of the latest stable release of
  the project. This allows people to quickly install m8c on their machine, by
  referencing the github project.

Added some documentation on how to use nix to automatically pull
dependencies, or quickly install m8c locally.