### PR TITLE
Cleanly exit with valid error message on serial port error

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,22 @@ $ ./m8c
 INFO: Looking for USB serial devices.
 INFO: Found M8 in /dev/ttyACM1.
 INFO: Opening port.
-Aborted (core dumped)
+ERROR: Error: Failed: Permission denied
 ```
 
-This is likely an issue with the version of libserialport included in your Linux distribution and you need to build the library yourself. Please see [this issue for a workaround](https://github.com/laamaa/m8c/issues/20).
+This is likely caused because the user running m8c does not have permission to use the serial port. The eaiest way to fix this is to add the current user to a group with permission to use the serial port.
+
+On Linux systems, look at the permissions on the serial port shown on the line that says "Found M8 in":
+```
+$ ls -la /dev/ttyACM1
+crw-rw---- 1 root dialout 166, 0 Jan  8 14:51 /dev/ttyACM0
+```
+
+This shows that the serial port is owned by the user 'root' and the grou 'dialout'. Both the user and the group have read/write permissions. To add a user to the group, run this command, replacing 'dialout' with the group shown on your own system:
+
+    sudo adduser $USER dialout
+
+You may need to log out and back in or even fully reboot the system for this change to take effect, but this will hopefully fix the problem. Please see [this issue for more details](https://github.com/laamaa/m8c/issues/20).
 
 -----------
 

--- a/serial.c
+++ b/serial.c
@@ -61,15 +61,27 @@ struct sp_port *init_serial() {
   sp_free_port_list(port_list);
 
   if (m8_port != NULL) {
-    // Open the serial port and configure it
-    SDL_Log("Opening port.\n");
-    check(sp_open(m8_port, SP_MODE_READ_WRITE));
+      // Open the serial port and configure it
+      SDL_Log("Opening port.\n");
+      enum sp_return result;
 
-    check(sp_set_baudrate(m8_port, 115200));
-    check(sp_set_bits(m8_port, 8));
-    check(sp_set_parity(m8_port, SP_PARITY_NONE));
-    check(sp_set_stopbits(m8_port, 1));
-    check(sp_set_flowcontrol(m8_port, SP_FLOWCONTROL_NONE));
+      result = sp_open(m8_port, SP_MODE_READ_WRITE);
+      if (check(result) != SP_OK) return NULL;
+      
+      result = sp_set_baudrate(m8_port, 115200);
+      if (check(result) != SP_OK) return NULL;
+      
+      result = sp_set_bits(m8_port, 8);
+      if (check(result) != SP_OK) return NULL;
+      
+      result = sp_set_parity(m8_port, SP_PARITY_NONE);
+      if (check(result) != SP_OK) return NULL;
+      
+      result = sp_set_stopbits(m8_port, 1);
+      if (check(result) != SP_OK) return NULL;
+      
+      result = sp_set_flowcontrol(m8_port, SP_FLOWCONTROL_NONE);
+      if (check(result) != SP_OK) return NULL;
   } else {
     SDL_LogCritical(SDL_LOG_CATEGORY_SYSTEM, "Cannot find a M8.\n");
   }
@@ -84,21 +96,22 @@ static int check(enum sp_return result) {
 
   switch (result) {
   case SP_ERR_ARG:
-    SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error: Invalid argument.\n");
-    abort();
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error: Invalid argument.\n");
+    break;
   case SP_ERR_FAIL:
     error_message = sp_last_error_message();
-    SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error: Failed: %s\n", error_message);
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error: Failed: %s\n", error_message);
     sp_free_error_message(error_message);
-    abort();
+    break;
   case SP_ERR_SUPP:
-    SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error: Not supported.\n");
-    abort();
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error: Not supported.\n");
+    break;
   case SP_ERR_MEM:
-    SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error: Couldn't allocate memory.\n");
-    abort();
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error: Couldn't allocate memory.\n");
+    break;
   case SP_OK:
   default:
-    return result;
+      break;
   }
+  return result;
 }


### PR DESCRIPTION
Log serial port messages to a category level that is enabled by default
Update FAQ to explain how to fix serial port permission problems