### PR TITLE
Fix serial read error checking bug

### DIFF
--- a/main.c
+++ b/main.c
@@ -107,7 +107,7 @@ int main(int argc, char *argv[]) {
     }
 
     // read serial port
-    size_t bytes_read = sp_blocking_read(port, serial_buf, serial_read_size, 3);
+    int bytes_read = sp_blocking_read(port, serial_buf, serial_read_size, 3);
     if (bytes_read < 0) {
       SDL_LogCritical(SDL_LOG_CATEGORY_ERROR, "Error %d reading serial. \n",
                       (int)bytes_read);


### PR DESCRIPTION
`size_t` is unsigned, so `sp_blocking_read()` errors are cast to a non-negative value and skip the check on line 111.

This also causes `bytes_read` to appear to be a very large number (much bigger than `serial_read_size`) which sends lots of junk to the SLIP call and eventually causes a segfault.

This can be duplicated for test by starting the M8 without an SD card inserted or by unplugging the M8 from USB after it has launched. 
Old behavior: Floods of `SLIP error 1` messages, then a segfault.
New behavior: 
```
CRITICAL: Error -2 reading serial. 
2022-02-26 23:37:08.338 m8c[15120:28714504] INFO: Shutting down
2022-02-26 23:37:08.360 m8c[15120:28714504] INFO: Disconnecting M8
2022-02-26 23:37:08.360 m8c[15120:28714504] ERROR: Error sending disconnect, code -2
```
(program terminates)