### PR TITLE
Update to build clean on macOS 10.11 with M1 cpu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,12 @@ OBJ = main.o serial.o slip.o command.o write.o render.o ini.o config.o input.o f
 DEPS = serial.h slip.h command.h write.h render.h ini.h config.h input.h
 
 #Any special libraries you are using in your project (e.g. -lbcm2835 -lrt `pkg-config --libs gtk+-3.0` ), or leave blank
-INCLUDES = -lserialport
+INCLUDES = $(shell pkg-config --libs sdl2 libserialport)
+
+
 
 #Set any compiler flags you want to use (e.g. -I/usr/include/somefolder `pkg-config --cflags gtk+-3.0` ), or leave blank
-CFLAGS = `sdl2-config --libs --cflags` -march=native -Wall -O2 -pipe -I.
+CFLAGS = $(shell pkg-config --cflags sdl2 libserialport) -mcpu=apple-m1 -Wall -O2 -pipe -I.
 
 #Set the compiler you are using ( gcc for C or g++ for C++ )
 CC = gcc
@@ -26,7 +28,7 @@ m8c: $(OBJ)
 	$(CC) -o $@ $^ $(CFLAGS) $(INCLUDES)
 
 font.c: inline_font.h
-	@echo "#include <SDL2/SDL.h>" > $@-tmp1
+	@echo "#include <SDL.h>" > $@-tmp1
 	@cat inline_font.h >> $@-tmp1
 	@cat inprint2.c > $@-tmp2
 	@sed '/#include/d' $@-tmp2 >> $@-tmp1

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ INCLUDES = $(shell pkg-config --libs sdl2 libserialport)
 
 
 #Set any compiler flags you want to use (e.g. -I/usr/include/somefolder `pkg-config --cflags gtk+-3.0` ), or leave blank
-CFLAGS = $(shell pkg-config --cflags sdl2 libserialport) -mcpu=apple-m1 -Wall -O2 -pipe -I.
+CFLAGS = $(shell pkg-config --cflags sdl2 libserialport) -Wall -O2 -pipe -I.
 
 #Set the compiler you are using ( gcc for C or g++ for C++ )
 CC = gcc

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sudo apt update && sudo apt install -y git gcc make libsdl2-dev libserialport-de
 This assumes you have [installed brew](https://docs.brew.sh/Installation)
 
 ```
-brew update && brew install -y git gcc make sdl2 libserialport
+brew update && brew install -y git gcc make sdl2 libserialport pkg-config
 ```
 ### Download source code (All)
 

--- a/SDL2_inprint.h
+++ b/SDL2_inprint.h
@@ -5,7 +5,7 @@
 #ifndef SDL2_inprint_h
 #define SDL2_inprint_h
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 extern void prepare_inline_font(void);
 extern void kill_inline_font(void);

--- a/command.c
+++ b/command.c
@@ -1,7 +1,7 @@
 // Copyright 2021 Jonne Kokkonen
 // Released under the MIT licence, https://opensource.org/licenses/MIT
 
-#include <SDL2/SDL_log.h>
+#include <SDL_log.h>
 
 #include "command.h"
 #include "render.h"

--- a/config.c
+++ b/config.c
@@ -2,7 +2,7 @@
 // Released under the MIT licence, https://opensource.org/licenses/MIT
 
 #include "config.h"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 config_params_s init_config() {
   config_params_s c;

--- a/input.c
+++ b/input.c
@@ -1,7 +1,7 @@
 // Copyright 2021 Jonne Kokkonen
 // Released under the MIT licence, https://opensource.org/licenses/MIT
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <stdio.h>
 
 #include "config.h"

--- a/main.c
+++ b/main.c
@@ -1,7 +1,7 @@
 // Copyright 2021 Jonne Kokkonen
 // Released under the MIT licence, https://opensource.org/licenses/MIT
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <libserialport.h>
 #include <signal.h>
 #include <string.h>

--- a/render.c
+++ b/render.c
@@ -3,7 +3,7 @@
 
 #include "render.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <stdio.h>
 
 #include "SDL2_inprint.h"

--- a/serial.c
+++ b/serial.c
@@ -4,7 +4,7 @@
 // Contains portions of code from libserialport's examples released to the
 // public domain
 
-#include <SDL2/SDL_log.h>
+#include <SDL_log.h>
 #include <libserialport.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/write.c
+++ b/write.c
@@ -1,7 +1,7 @@
 // Copyright 2021 Jonne Kokkonen
 // Released under the MIT licence, https://opensource.org/licenses/MIT
 
-#include <SDL2/SDL_log.h>
+#include <SDL_log.h>
 #include <libserialport.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
~~**This will break builds in its current state**~~
_Update: Welp, wasn't expecting to pass all three tests...lol Probably should still be checked on RPi before integration though_

This commit fixes one major and a few minor compilation issues on macOS 10.11 on M1 silicon.

The biggest issue is that gcc on M1 doesn't seem to support `-march=native` (or the `-march` flag at all..)
There are two ways to approach this:
- replace with `-mcpu=apple-m1`
- remove `-march=native` and don't replace it

The first option may be preferable for RPi targets, since you probably want to squeeze every bit of performance out of what you have. Processor-specific compilation may improve battery performance on the M1 as well-- no testing done there.

If you want to keep processor-specific builds, a conditional compilation or multiple makefiles need to be set up to keep this aspect from breaking builds.

Moving to `pkg-config` _should_ be portable, but that definitely needs testing. Using `pkg-config` this way silences a bunch of warnings on my setup, but is more specific about the SDL directory location than the previous method.
