### PR TITLE
Add instructions and prepare script for Steam Deck compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,36 @@ Connect the M8 or Teensy (with headless firmware) to your computer and start the
 
 If the stars are aligned correctly, you should see the M8 screen.
 
+## Steam Deck (custom Arch Linux)
+1. Reboot Steam Deck into Desktop Mode
+2. Launch the _System > Konsole_ terminal application
+3. Clone this repository:
+```
+mkdir code && cd code
+git clone https://github.com/laamaa/m8c.git
+cd m8c
+```
+4. Set a sudo passwd:
+```
+passwd
+```
+5. Run the Steam Deck prepare script and enter the sudo password set previously:
+```
+./scripts/prepare-steamdeck.sh
+```
+6. Compile the m8c application:
+```
+make
+```
+7. Reboot the Steam Deck and switch back to Decktop Mode to pick up the permissions required to access the M8 over serial USB.
+8. Connect your M8
+9. Launch the app from Konsole
+```
+cd ~/code/m8c
+./m8c
+```
+9. Make music
+
 -----------
 
 ## Keyboard mappings

--- a/scripts/prepare-steamdeck.sh
+++ b/scripts/prepare-steamdeck.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This script will configure your Steam Deck to allow you to compile the m8c application.  Steam Deck runs an Arch Linux.
+
+# NOTE: To use this script you need to set a sudo password using the passwd command.
+
+# Disable readonly file system (https://help.steampowered.com/en/faqs/view/671A-4453-E8D2-323C)
+echo "Disabling Steam Deck readonly file system"
+sudo steamos-readonly disable
+
+# Initialize and populate the pacman keyring
+echo "Initializing and populating pacman keyring"
+sudo pacman-key --init
+sudo pacman-key --populate archlinux
+
+# Install libserialport
+echo "Installing libSerialPort"
+sudo pacman -S --noconfirm libserialport
+
+# Install sdl2
+echo "Installing SDL2"
+sudo pacman -S --noconfirm sdl2
+
+# Install glibc
+echo "Installing glibC"
+sudo pacman -S noconfirm glibc
+
+# Add deck user to uucp group to allow access to m8 serial
+echo "Enabling serial port access"
+sudo gpasswd -a deck uucp
+
+
+echo -e "\nPreparation complete.  Please compile m8c using 'make' and then REBOOT your Steam Deck to pick up new serial port permissions."

--- a/scripts/prepare-steamdeck.sh
+++ b/scripts/prepare-steamdeck.sh
@@ -22,7 +22,7 @@ sudo pacman -S --noconfirm sdl2
 
 # Install glibc
 echo "Installing glibC"
-sudo pacman -S noconfirm glibc
+sudo pacman -S --noconfirm glibc
 
 # Add deck user to uucp group to allow access to m8 serial
 echo "Enabling serial port access"


### PR DESCRIPTION
The script simplifies the steps needed to prepare the Steam Deck, based on Arch Linux, to be able to compile the m8c application.