### PR TITLE
Improve idle performance and other enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ INCLUDES = $(shell pkg-config --libs sdl2 libserialport)
 
 
 #Set any compiler flags you want to use (e.g. -I/usr/include/somefolder `pkg-config --cflags gtk+-3.0` ), or leave blank
-CFLAGS = $(shell pkg-config --cflags sdl2 libserialport) -Wall -O2 -pipe -I.
+local_CFLAGS = $(CFLAGS) $(shell pkg-config --cflags sdl2 libserialport) -Wall -O2 -pipe -I.
 
 #Set the compiler you are using ( gcc for C or g++ for C++ )
 CC = gcc
@@ -20,12 +20,12 @@ EXTENSION = .c
 
 #define a rule that applies to all files ending in the .o suffix, which says that the .o file depends upon the .c version of the file and all the .h files included in the DEPS macro.  Compile each object file
 %.o: %$(EXTENSION) $(DEPS)
-	$(CC) -c -o $@ $< $(CFLAGS)
+	$(CC) -c -o $@ $< $(local_CFLAGS)
 
 #Combine them into the output file
 #Set your desired exe output file name here
 m8c: $(OBJ)
-	$(CC) -o $@ $^ $(CFLAGS) $(INCLUDES)
+	$(CC) -o $@ $^ $(local_CFLAGS) $(INCLUDES)
 
 font.c: inline_font.h
 	@echo "#include <SDL.h>" > $@-tmp1
@@ -35,7 +35,7 @@ font.c: inline_font.h
 	@rm $@-tmp2
 	@mv $@-tmp1 $@
 	@echo "[~cat] inline_font.h inprint2.c > font.c"
-#	$(CC) -c -o font.o font.c $(CFLAGS)
+#	$(CC) -c -o font.o font.c $(local_CFLAGS)
 
 #Cleanup
 .PHONY: clean


### PR DESCRIPTION
- Add dirty flag to only render after draw commands
- Modify oscilloscope draw command to suppress empty redraws
- Add ability to make a debug build from the command line
- Slightly optimize byte copies to SLIP parser

The `dirty` flag is an alternate solution for fixing the fx palette bug, but it can still add some value since it's a more flexible way to control when frames get drawn. For example, I've used it to suppress empty oscilloscope draws while M8 is not playing, which reduces the CPU usage significantly during idle.

Debug logging can now be enabled from the `make` command without editing the source code:
`make CFLAGS=-DDEBUG_MSG`