### PR TITLE
CPU utilization improvements, minor enhancements, and other bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ INCLUDES = $(shell pkg-config --libs sdl2 libserialport)
 
 
 #Set any compiler flags you want to use (e.g. -I/usr/include/somefolder `pkg-config --cflags gtk+-3.0` ), or leave blank
-CFLAGS = $(shell pkg-config --cflags sdl2 libserialport) -Wall -O2 -pipe -I.
+local_CFLAGS = $(CFLAGS) $(shell pkg-config --cflags sdl2 libserialport) -Wall -O2 -pipe -I.
 
 #Set the compiler you are using ( gcc for C or g++ for C++ )
 CC = gcc
@@ -20,12 +20,12 @@ EXTENSION = .c
 
 #define a rule that applies to all files ending in the .o suffix, which says that the .o file depends upon the .c version of the file and all the .h files included in the DEPS macro.  Compile each object file
 %.o: %$(EXTENSION) $(DEPS)
-	$(CC) -c -o $@ $< $(CFLAGS)
+	$(CC) -c -o $@ $< $(local_CFLAGS)
 
 #Combine them into the output file
 #Set your desired exe output file name here
 m8c: $(OBJ)
-	$(CC) -o $@ $^ $(CFLAGS) $(INCLUDES)
+	$(CC) -o $@ $^ $(local_CFLAGS) $(INCLUDES)
 
 font.c: inline_font.h
 	@echo "#include <SDL.h>" > $@-tmp1
@@ -35,7 +35,7 @@ font.c: inline_font.h
 	@rm $@-tmp2
 	@mv $@-tmp1 $@
 	@echo "[~cat] inline_font.h inprint2.c > font.c"
-#	$(CC) -c -o font.o font.c $(CFLAGS)
+#	$(CC) -c -o font.o font.c $(local_CFLAGS)
 
 #Cleanup
 .PHONY: clean

--- a/config.c
+++ b/config.c
@@ -23,6 +23,7 @@ config_params_s init_config() {
 
   c.init_fullscreen = 0;  // default fullscreen state at load
   c.init_use_gpu = 1;     // default to use hardware acceleration
+  c.idle_ms = 10;         // default to high performance
 
   c.key_up = SDL_SCANCODE_UP;
   c.key_left = SDL_SCANCODE_LEFT;
@@ -78,6 +79,7 @@ void write_config(config_params_s *conf) {
           conf->init_fullscreen ? "true" : "false");
   sprintf(ini_values[initPointer++], "use_gpu=%s\n",
           conf->init_use_gpu ? "true" : "false");
+  sprintf(ini_values[initPointer++], "idle_ms=%d\n", conf->idle_ms);
   sprintf(ini_values[initPointer++], "[keyboard]\n");
   sprintf(ini_values[initPointer++], "key_up=%d\n", conf->key_up);
   sprintf(ini_values[initPointer++], "key_left=%d\n", conf->key_left);
@@ -164,6 +166,7 @@ void read_config(config_params_s *conf) {
 void read_graphics_config(ini_t *ini, config_params_s *conf) {
   const char *param_fs = ini_get(ini, "graphics", "fullscreen");
   const char *param_gpu = ini_get(ini, "graphics", "use_gpu");
+  const char *idle_ms = ini_get(ini, "graphics", "idle_ms");
 
   if (strcmpci(param_fs, "true") == 0) {
     conf->init_fullscreen = 1;
@@ -176,6 +179,9 @@ void read_graphics_config(ini_t *ini, config_params_s *conf) {
     } else
       conf->init_use_gpu = 0;
   }
+
+  if (idle_ms)
+    conf->idle_ms = SDL_atoi(idle_ms);
 
 }
 

--- a/config.c
+++ b/config.c
@@ -4,6 +4,7 @@
 #include "config.h"
 #include "ini.h"
 #include <SDL.h>
+#include <assert.h>
 
 /* Case insensitive string compare from ini.h library */
 static int strcmpci(const char *a, const char *b) {
@@ -71,8 +72,10 @@ void write_config(config_params_s *conf) {
 
   SDL_Log("Writing config file to %s", config_path);
 
+  const unsigned int INI_LINE_COUNT = 36;
+
   // Entries for the config file
-  char ini_values[35][50];
+  char ini_values[INI_LINE_COUNT][50];
   int initPointer = 0;
   sprintf(ini_values[initPointer++], "[graphics]\n");
   sprintf(ini_values[initPointer++], "fullscreen=%s\n",
@@ -121,9 +124,12 @@ void write_config(config_params_s *conf) {
   sprintf(ini_values[initPointer++], "gamepad_analog_axis_edit=%d\n",
           conf->gamepad_analog_axis_edit);
 
+  // Ensure we aren't writing off the end of the array
+  assert(initPointer == INI_LINE_COUNT);
+
   if (rw != NULL) {
     // Write ini_values array to config file
-    for (int i = 0; i < 34; i++) {
+    for (int i = 0; i < INI_LINE_COUNT; i++) {
       size_t len = SDL_strlen(ini_values[i]);
       if (SDL_RWwrite(rw, ini_values[i], 1, len) != len) {
         SDL_LogDebug(SDL_LOG_CATEGORY_SYSTEM,

--- a/config.h
+++ b/config.h
@@ -10,6 +10,7 @@ typedef struct config_params_s {
   char *filename;
   int init_fullscreen;
   int init_use_gpu;
+  int idle_ms;
 
   int key_up;
   int key_left;

--- a/ini.c
+++ b/ini.c
@@ -194,6 +194,9 @@ ini_t* ini_load(const char *filename) {
   /* Get file size */
   fseek(fp, 0, SEEK_END);
   sz = ftell(fp);
+  if (sz==0) {
+    goto fail;
+  }
   rewind(fp);
 
   /* Load file content into memory, null terminate, init end var */

--- a/main.c
+++ b/main.c
@@ -35,8 +35,6 @@ int main(int argc, char *argv[]) {
   // TODO: take cli parameter to override default configfile location
   read_config(&conf);
 
-  SDL_Log("idle_ms=%d", conf.idle_ms);
-
   // allocate memory for serial buffer
   uint8_t *serial_buf = malloc(serial_read_size);
 
@@ -117,7 +115,6 @@ int main(int argc, char *argv[]) {
 
     while (1) {
       // read serial port
-      //int bytes_read = sp_blocking_read(port, serial_buf, serial_read_size, 1);
       int bytes_read = sp_nonblocking_read(port, serial_buf, serial_read_size);
       if (bytes_read < 0) {
         SDL_LogCritical(SDL_LOG_CATEGORY_ERROR, "Error %d reading serial. \n",

--- a/main.c
+++ b/main.c
@@ -35,6 +35,8 @@ int main(int argc, char *argv[]) {
   // TODO: take cli parameter to override default configfile location
   read_config(&conf);
 
+  SDL_Log("idle_ms=%d", conf.idle_ms);
+
   // allocate memory for serial buffer
   uint8_t *serial_buf = malloc(serial_read_size);
 
@@ -115,7 +117,8 @@ int main(int argc, char *argv[]) {
 
     while (1) {
       // read serial port
-      int bytes_read = sp_blocking_read(port, serial_buf, serial_read_size, 1);
+      //int bytes_read = sp_blocking_read(port, serial_buf, serial_read_size, 1);
+      int bytes_read = sp_nonblocking_read(port, serial_buf, serial_read_size);
       if (bytes_read < 0) {
         SDL_LogCritical(SDL_LOG_CATEGORY_ERROR, "Error %d reading serial. \n",
                         (int)bytes_read);
@@ -140,6 +143,7 @@ int main(int argc, char *argv[]) {
       }
     }
     render_screen();
+    SDL_Delay(conf.idle_ms);
   }
 
   // exit, clean up

--- a/render.c
+++ b/render.c
@@ -203,7 +203,7 @@ void display_keyjazz_overlay(uint8_t show, uint8_t base_octave) {
 }
 
 void render_screen() {
-  if (dirty && (SDL_GetTicks() - ticks > 14)) {
+  if (dirty) {
     dirty = 0;
     ticks = SDL_GetTicks();
     SDL_SetRenderTarget(rend, NULL);


### PR DESCRIPTION
Enhance idle performance:
- Modify oscilloscope draw command to suppress empty redraws

Improve general CPU usage:
- Change to nonblocking calls to serial read
- Moves main thread delay to an SDL_Delay() call
- Adds an INI parameter to control SDL_Delay() argument / thread sleep time

(Moving to SDL_Delay may or may not work well on a wide range of platforms)

Fix bugs:
- Fix buffer overflow in INI write (oops!)
- Add assert to guard similar errors
- Fix bug that failed to write last line of INI file (existing bug)
- Fix segfault on reading empty INI file (existing bug)

Enhancements:
- Add dirty flag to only render after draw commands (alternate solution to palette fx bug)
- Add ability to make a debug build from the command line
- Slightly optimize byte copies to SLIP parser