### PR TITLE
initialize sdl before resetting display, add sdl_quit() to exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 m8c
 .vscode
+.cache/
 font.c
 build/
 compile_commands.json

--- a/main.c
+++ b/main.c
@@ -58,10 +58,10 @@ int main(int argc, char *argv[]) {
   if (port == NULL)
     return -1;
 
-  if (enable_and_reset_display(port) == -1)
+  if (initialize_sdl(conf.init_fullscreen, conf.init_use_gpu) == -1)
     run = 0;
 
-  if (initialize_sdl(conf.init_fullscreen, conf.init_use_gpu) == -1)
+  if (enable_and_reset_display(port) == -1)
     run = 0;
 
   uint8_t prev_input = 0;
@@ -138,6 +138,6 @@ int main(int argc, char *argv[]) {
   sp_close(port);
   sp_free_port(port);
   free(serial_buf);
-
+  SDL_Quit();
   return 0;
 }


### PR DESCRIPTION
Fixes graphical glitches on startup and random butchering of desktop on exit