### PR TITLE
Add m8c build workflow job for Arch Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,39 @@ jobs:
             m8c
             gamecontrollerdb.txt
             config.ini.sample
+
+  build-arch-linux:
+    runs-on: ubuntu-latest
+    name: arch-linux-x86_64
+    container:
+      image: archlinux:base-20230611.0.157136
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+
+      - name: 'Update packages'
+        run: pacman -Syu --noconfirm
+
+      - name: 'Install dependencies'
+        run: pacman -S gcc git make sdl2 libserialport pkgconf --noconfirm
+
+      - name: 'Build package'
+        run: make
+
+      - name: 'Set current date as env variable'
+        run: echo "NOW=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      
+      - name: 'Upload artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: m8c-${{ env.NOW }}-arch-linux
+          path: |
+            LICENSE
+            README.md
+            AUDIOGUIDE.md
+            m8c
+            gamecontrollerdb.txt
+            config.ini.sample
       
   build-macos:
     runs-on: macos-latest

--- a/README.md
+++ b/README.md
@@ -24,23 +24,47 @@ Disclaimer: I'm not a coder and hardly understand C, use at your own risk :)
 
 # Installation
 
-## Windows / MacOS
+## Windows / MacOS / Ubuntu / Arch Linux
 
-There are prebuilt binaries available in the [releases section](https://github.com/laamaa/m8c/releases/) for Windows and recent versions of MacOS.
+There are prebuilt binaries available in the [releases section](https://github.com/laamaa/m8c/releases/) for Windows, recent versions of MacOS, Ubuntu and Arch Linux.
 
-## Linux / MacOS (building from source)
+### Ubuntu / Arch Linux
 
-These instructions are tested with Raspberry Pi 3 B+ and Raspberry Pi OS with desktop (March 4 2021 release), but should apply for other Debian/Ubuntu flavors as well. The begining on the build process on OSX is slightly different at the start, and then the same once packages are installed.
+`m8c` requires the `libserialport` package to be present on your machine. Use the following commands to install it:
 
-The instructions assume that you already have a working Linux desktop installation with an internet connection.
+#### Ubuntu
+
+```shell
+sudo apt update && sudo apt install -y libserialport-dev
+```
+
+#### Arch Linux
+
+```shell
+pacman -Syu && pacman -S libserialport
+```
+
+## Ubuntu / Arch Linux / MacOS (building from source)
+
+These instructions are tested with Raspberry Pi 3 B+ running Raspberry Pi OS with desktop (March 4 2021 release) and Arch Linux. Other Debian/Ubuntu flavors should work as well. The begining on the build process on OSX and Arch Linux is slightly different at the start, and then the same once packages are installed.
+
+The instructions assume that you already have a working Ubuntu / Arch Linux desktop installation with an internet connection.
 
 Open Terminal and run the following commands:
 
-### Install required packages (Raspberry Pi, Linux)
+### Install required packages (Raspberry Pi, Ubuntu)
 
 ```
 sudo apt update && sudo apt install -y git gcc make libsdl2-dev libserialport-dev
 ```
+
+### Install required packages (Arch Linux)
+
+```shell
+pacman -Syu
+pacman -S gcc git make sdl2 libserialport pkgconf
+```
+
 ### Install required packages (OSX)
 
 This assumes you have [installed brew](https://docs.brew.sh/Installation)


### PR DESCRIPTION
Closes #119 and #116

Changes:
* Add build job to the Github Workflow for building the m8c binary for Arch Linux
* Mention prebuilt binaries for Linux in the README.md
* Add instructions on how to perform the build on Arch Linux to the README.md
* When using prebuilt binaries, mention the libserialport dependency for Linux

Tested on SteamOS (Arch-based Linux distro) 3.4.6.

In case anyone wants to try the binary for themselves, check the artifacts from the latest build of my fork:

https://github.com/erNail/m8c/actions/runs/5321878148
https://github.com/erNail/m8c/suites/13728817537/artifacts/759679709