### PR TITLE
Feat/jazzkeys keys config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -47,6 +47,10 @@ config_params_s init_config() {
   c.key_edit_alt = SDL_SCANCODE_S;
   c.key_delete = SDL_SCANCODE_DELETE;
   c.key_reset = SDL_SCANCODE_R;
+  c.key_jazz_inc_octave = SDL_SCANCODE_KP_MULTIPLY;
+  c.key_jazz_dec_octave = SDL_SCANCODE_KP_DIVIDE;
+  c.key_jazz_inc_velocity = SDL_SCANCODE_KP_MINUS;
+  c.key_jazz_dec_velocity = SDL_SCANCODE_KP_PLUS;
 
   c.gamepad_up = SDL_CONTROLLER_BUTTON_DPAD_UP;
   c.gamepad_left = SDL_CONTROLLER_BUTTON_DPAD_LEFT;
@@ -82,7 +86,7 @@ void write_config(config_params_s *conf) {
 
   SDL_Log("Writing config file to %s", config_path);
 
-  const unsigned int INI_LINE_COUNT = 44;
+  const unsigned int INI_LINE_COUNT = 48;
   const unsigned int LINELEN = 50;
 
   // Entries for the config file
@@ -129,6 +133,14 @@ void write_config(config_params_s *conf) {
            conf->key_delete);
   snprintf(ini_values[initPointer++], LINELEN, "key_reset=%d\n",
            conf->key_reset);
+  snprintf(ini_values[initPointer++], LINELEN, "key_jazz_inc_octave=%d\n",
+           conf->key_jazz_inc_octave);
+  snprintf(ini_values[initPointer++], LINELEN, "key_jazz_dec_octave=%d\n",
+           conf->key_jazz_dec_octave);
+  snprintf(ini_values[initPointer++], LINELEN, "key_jazz_inc_velocity=%d\n",
+           conf->key_jazz_inc_velocity);
+  snprintf(ini_values[initPointer++], LINELEN, "key_jazz_dec_velocity=%d\n",
+           conf->key_jazz_dec_velocity);
   snprintf(ini_values[initPointer++], LINELEN, "[gamepad]\n");
   snprintf(ini_values[initPointer++], LINELEN, "gamepad_up=%d\n",
            conf->gamepad_up);
@@ -289,6 +301,10 @@ void read_key_config(ini_t *ini, config_params_s *conf) {
   const char *key_edit_alt = ini_get(ini, "keyboard", "key_edit_alt");
   const char *key_delete = ini_get(ini, "keyboard", "key_delete");
   const char *key_reset = ini_get(ini, "keyboard", "key_reset");
+  const char *key_jazz_inc_octave = ini_get(ini, "keyboard", "key_jazz_inc_octave");
+  const char *key_jazz_dec_octave = ini_get(ini, "keyboard", "key_jazz_dec_octave");
+  const char *key_jazz_inc_velocity = ini_get(ini, "keyboard", "key_jazz_inc_velocity");
+  const char *key_jazz_dec_velocity = ini_get(ini, "keyboard", "key_jazz_dec_velocity");
 
   if (key_up)
     conf->key_up = SDL_atoi(key_up);
@@ -318,6 +334,14 @@ void read_key_config(ini_t *ini, config_params_s *conf) {
     conf->key_delete = SDL_atoi(key_delete);
   if (key_reset)
     conf->key_reset = SDL_atoi(key_reset);
+  if (key_jazz_inc_octave)
+    conf->key_jazz_inc_octave = SDL_atoi(key_jazz_inc_octave);
+  if (key_jazz_dec_octave)
+    conf->key_jazz_dec_octave = SDL_atoi(key_jazz_dec_octave);
+  if (key_jazz_inc_velocity)
+    conf->key_jazz_inc_velocity = SDL_atoi(key_jazz_inc_velocity);
+  if (key_jazz_dec_velocity)
+    conf->key_jazz_dec_velocity = SDL_atoi(key_jazz_dec_velocity);
 }
 
 void read_gamepad_config(ini_t *ini, config_params_s *conf) {

--- a/src/config.h
+++ b/src/config.h
@@ -31,6 +31,10 @@ typedef struct config_params_s {
   int key_edit_alt;
   int key_delete;
   int key_reset;
+  int key_jazz_inc_octave;
+  int key_jazz_dec_octave;
+  int key_jazz_inc_velocity;
+  int key_jazz_dec_velocity;
 
   int gamepad_up;
   int gamepad_left;

--- a/src/input.c
+++ b/src/input.c
@@ -98,6 +98,15 @@ void close_game_controllers() {
   }
 }
 
+typedef struct KeyState {
+    int key_jazz_dec_octave_handled;
+    int key_jazz_inc_octave_handled;
+    int key_jazz_dec_velocity_handled;
+    int key_jazz_inc_velocity_handled;
+} KeyState;
+
+KeyState keyState = {0, 0, 0, 0};
+
 static input_msg_s handle_keyjazz(
   SDL_Event *event,
   uint8_t keyvalue,
@@ -195,33 +204,52 @@ static input_msg_s handle_keyjazz(
   default:
     key.type = normal;
     if (event->key.keysym.scancode == conf->key_jazz_dec_octave) {
-        if (event->type == SDL_KEYDOWN && keyjazz_base_octave > 0) {
-            keyjazz_base_octave--;
-            display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
-        }
+      if (event->type == SDL_KEYDOWN && !keyState.key_jazz_dec_octave_handled && keyjazz_base_octave > 0) {
+        keyState.key_jazz_dec_octave_handled = 1;
+        keyjazz_base_octave--;
+        display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
+      } else if (event->type == SDL_KEYUP) {
+        keyState.key_jazz_dec_octave_handled = 0;
+      }
     } else if (event->key.keysym.scancode == conf->key_jazz_inc_octave) {
-        if (event->type == SDL_KEYDOWN && keyjazz_base_octave < 8) {
-            keyjazz_base_octave++;
-            display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
-        }
+      if (event->type == SDL_KEYDOWN && !keyState.key_jazz_inc_octave_handled && keyjazz_base_octave < 8) {
+        keyState.key_jazz_inc_octave_handled = 1;
+        keyjazz_base_octave++;
+        display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
+      } else if (event->type == SDL_KEYUP) {
+        keyState.key_jazz_inc_octave_handled = 0;
+      }
     } else if (event->key.keysym.scancode == conf->key_jazz_dec_velocity) {
+      if (event->type == SDL_KEYDOWN && !keyState.key_jazz_dec_velocity_handled) {
+        keyState.key_jazz_dec_velocity_handled = 1;
         if ((event->key.keysym.mod & KMOD_ALT) > 0) {
-            if (keyjazz_velocity > 1)
-                keyjazz_velocity -= 1;
+          if (keyjazz_velocity > 1) {
+            keyjazz_velocity -= 1;
+          }
         } else {
-            if (keyjazz_velocity > 0x10)
-                keyjazz_velocity -= 0x10;
+          if (keyjazz_velocity > 0x10)
+            keyjazz_velocity -= 0x10;
         }
         display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
+      } else if (event->type == SDL_KEYUP) {
+        keyState.key_jazz_dec_velocity_handled = 0;
+      }
     } else if (event->key.keysym.scancode == conf->key_jazz_inc_velocity) {
+      if (event->type == SDL_KEYDOWN && !keyState.key_jazz_inc_velocity_handled) {
+        keyState.key_jazz_inc_velocity_handled = 1;
         if ((event->key.keysym.mod & KMOD_ALT) > 0) {
-            if (keyjazz_velocity < 0x7F)
-                keyjazz_velocity += 1;
+          if (keyjazz_velocity < 0x7F) {
+            keyjazz_velocity += 1;
+          }
         } else {
-            if (keyjazz_velocity < 0x6F)
-                keyjazz_velocity += 0x10;
+          if (keyjazz_velocity < 0x6F) {
+            keyjazz_velocity += 0x10;
+          }
         }
         display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
+      } else if (event->type == SDL_KEYUP) {
+        keyState.key_jazz_inc_velocity_handled = 0;
+      }
     }
     break;
   }

--- a/src/input.c
+++ b/src/input.c
@@ -98,7 +98,11 @@ void close_game_controllers() {
   }
 }
 
-static input_msg_s handle_keyjazz(SDL_Event *event, uint8_t keyvalue) {
+static input_msg_s handle_keyjazz(
+  SDL_Event *event,
+  uint8_t keyvalue,
+  config_params_s *conf
+) {
   input_msg_s key = {keyjazz, keyvalue, keyjazz_velocity, event->type};
   switch (event->key.keysym.scancode) {
   case SDL_SCANCODE_Z:
@@ -188,48 +192,37 @@ static input_msg_s handle_keyjazz(SDL_Event *event, uint8_t keyvalue) {
   case SDL_SCANCODE_P:
     key.value = 28 + keyjazz_base_octave * 12;
     break;
-  case SDL_SCANCODE_KP_DIVIDE:
-    key.type = normal;
-    if (event->type == SDL_KEYDOWN && keyjazz_base_octave > 0) {
-      keyjazz_base_octave--;
-      display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
-    }
-    break;
-  case SDL_SCANCODE_KP_MULTIPLY:
-    key.type = normal;
-    if (event->type == SDL_KEYDOWN && keyjazz_base_octave < 8) {
-      keyjazz_base_octave++;
-      display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
-    }
-    break;
-  case SDL_SCANCODE_KP_MINUS:
-    key.type = normal;
-    if (event->type == SDL_KEYDOWN) {
-      if ((event->key.keysym.mod & KMOD_ALT) > 0) {
-        if (keyjazz_velocity > 1)
-          keyjazz_velocity -= 1;
-      } else {
-        if (keyjazz_velocity > 0x10)
-          keyjazz_velocity -= 0x10;
-      }
-      display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
-    }
-    break;
-  case SDL_SCANCODE_KP_PLUS:
-    key.type = normal;
-    if (event->type == SDL_KEYDOWN) {
-      if ((event->key.keysym.mod & KMOD_ALT) > 0) {
-        if (keyjazz_velocity < 0x7F)
-          keyjazz_velocity += 1;
-      } else {
-        if (keyjazz_velocity < 0x6F)
-          keyjazz_velocity += 0x10;
-      }
-      display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
-    }
-    break;
   default:
     key.type = normal;
+    if (event->key.keysym.scancode == conf->key_jazz_dec_octave) {
+        if (event->type == SDL_KEYDOWN && keyjazz_base_octave > 0) {
+            keyjazz_base_octave--;
+            display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
+        }
+    } else if (event->key.keysym.scancode == conf->key_jazz_inc_octave) {
+        if (event->type == SDL_KEYDOWN && keyjazz_base_octave < 8) {
+            keyjazz_base_octave++;
+            display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
+        }
+    } else if (event->key.keysym.scancode == conf->key_jazz_dec_velocity) {
+        if ((event->key.keysym.mod & KMOD_ALT) > 0) {
+            if (keyjazz_velocity > 1)
+                keyjazz_velocity -= 1;
+        } else {
+            if (keyjazz_velocity > 0x10)
+                keyjazz_velocity -= 0x10;
+        }
+        display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
+    } else if (event->key.keysym.scancode == conf->key_jazz_inc_velocity) {
+        if ((event->key.keysym.mod & KMOD_ALT) > 0) {
+            if (keyjazz_velocity < 0x7F)
+                keyjazz_velocity += 1;
+        } else {
+            if (keyjazz_velocity < 0x6F)
+                keyjazz_velocity += 0x10;
+        }
+        display_keyjazz_overlay(1, keyjazz_base_octave, keyjazz_velocity);
+    }
     break;
   }
 
@@ -429,7 +422,7 @@ void handle_sdl_events(config_params_s *conf) {
     key = handle_normal_keys(&event, conf, 0);
 
     if (keyjazz_enabled)
-      key = handle_keyjazz(&event, key.value);
+      key = handle_keyjazz(&event, key.value, conf);
     break;
 
   default:

--- a/src/main.c
+++ b/src/main.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[]) {
     // try to init serial port
     int port_inited = init_serial(1);
     // if port init was successful, try to enable and reset display
-    if (port_inited == 1 && enable_and_reset_display(0) == 1) {
+    if (port_inited == 1 && enable_and_reset_display() == 1) {
       // if audio routing is enabled, try to initialize audio devices
       if (conf.audio_enabled == 1) {
         audio_init(conf.audio_buffer_size, conf.audio_device_name);

--- a/src/serial.h
+++ b/src/serial.h
@@ -3,6 +3,7 @@
 
 #ifndef _SERIAL_H_
 #define _SERIAL_H_
+#include <stdint.h>
 
 #ifdef USE_LIBUSB
 // Max packet length of the USB endpoint


### PR DESCRIPTION
These changes should allow to set the jazzkeys keys in the config. It also has a fix for an issue I had after doing the changes, where the velocity/octaves were changing if holding the key, which made it difficult to use because it was skipping the values too fast.

@laamaa Can you take a look and see if it works ok for you? I tried to keep the previous numpad keys as the default in the config. 

I think the readme could be updated if merging this feature. 

Thanks!