### PR TITLE
Use a Nix Flake for m8c

### DIFF
--- a/.github/workflows/nix-package.yml
+++ b/.github/workflows/nix-package.yml
@@ -1,4 +1,4 @@
-name: Update Version and Hash in default.nix
+name: Update Version and Hash in flake.nix
 
 on:
   push:
@@ -42,15 +42,15 @@ jobs:
             echo "valid=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Update version in default.nix
+      - name: Update version in flake.nix
         if: steps.valid-tag.outputs.valid
         run: |
           latest_annotated_tag="${{ steps.newest-tag.outputs.latest_annotated_tag }}"
           latest_annotated_tag_without_v="${latest_annotated_tag#v}"  # Remove 'v' prefix
-          sed -i "s/version = \".*\";/version = \"$latest_annotated_tag_without_v\";/" default.nix
+          sed -i "s/version = \".*\";/version = \"$latest_annotated_tag_without_v\";/" flake.nix
           new_hash=$(nix-prefetch-url --unpack --type sha256 "https://github.com/laamaa/m8c/archive/v$latest_annotated_tag_without_v.tar.gz")  # Use updated variable name
-          sed -i "s/hash = \".*\";/hash = \"sha256:$new_hash\";/" default.nix
+          sed -i "s/hash = \".*\";/hash = \"sha256:$new_hash\";/" flake.nix
           git config user.email "github-actions@github.com"
           git config user.name "GitHub Actions"
-          git commit -am "Update version and hash in default.nix to $latest_annotated_tag_without_v"
+          git commit -am "Update version and hash in flake.nix to $latest_annotated_tag_without_v"
           git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ sudo dnf install m8c
 nix-env -iA m8c-stable -f https://github.com/laamaa/m8c/archive/refs/heads/main.tar.gz
 ```
 
+Or if you're using flakes and the nix command, you can run the app directly with:
+
+```sh
+nix run github:laamaa/m8c
+```
+
 ### Building from source code
 
 #### Install dependencies

--- a/default.nix
+++ b/default.nix
@@ -1,47 +1,18 @@
-{ pkgs ? import <nixpkgs> {} }:
-
-with pkgs;
-
-# HOWTO keep this package definition up-to-date:
-#
-# 1. NEW VERSION:
-# After the new version is tagged and pushed, update the `version` var to the
-# proper value and update the hash. You can use the following command to find
-# out the sha256, for example, with version 1.0.3:
-# `nix-prefetch-github --rev v1.0.3 laamaa m8c`
-#
-# 2. NEW DEPENDENCIES:
-# Make sure new dependencies are added. Runtime deps go to buildInputs and
-# compile-time deps go to nativeBuildInputs. Use the nixpkgs manual for help
-#
-let m8c-package =
-  { stdenv
-  , gnumake
-  , pkg-config
-  , SDL2
-  , libserialport
-  , fetchFromGitHub
-  }:
-
-  let
-    pname = "m8c";
-    version = "1.7.6";
-  in
-    stdenv.mkDerivation {
-      inherit pname version;
-
-      src = fetchFromGitHub {
-        owner = "laamaa";
-        repo = pname;
-        rev = "v${version}";
-        hash = "sha256:1b2wg8zmxisn1kc3wkfzcij1707pz560yq8v6rwjirr0dd27a3n2";
-      };
-
-      installFlags = [ "PREFIX=$(out)" ];
-      nativeBuildInputs = [ gnumake pkg-config ];
-      buildInputs = [ SDL2 libserialport ];
-    };
-in {
-  m8c-stable = pkgs.callPackage m8c-package {};
-  m8c-dev = (pkgs.callPackage m8c-package {}).overrideAttrs (oldAttrs: {src = ./.;});
+let
+  pkgs = (import
+    (
+      let
+        lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+      in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+    )
+    {
+      src = ./.;
+    }).defaultNix.packages.${builtins.currentSystem};
+in
+{
+  inherit (pkgs) m8c-stable m8c-dev;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1721821769,
+        "narHash": "sha256-PhmkdTJs2SfqKzSyDB74rDKp1MH4mGk0pG/+WqrnGEw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d0907b75146a0ccc1ec0d6c3db287ec287588ef6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721769617,
+        "narHash": "sha256-6Pqa0bi5nV74IZcENKYRToRNM5obo1EQ+3ihtunJ014=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "8db8970be1fb8be9c845af7ebec53b699fe7e009",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,98 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    systems.url = "github:nix-systems/default";
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, systems, treefmt-nix, ... }:
+    let
+      # HOWTO keep this package definition up-to-date:
+      #
+      # 1. NEW VERSION:
+      # After the new version is tagged and pushed, update the `version` var to the
+      # proper value and update the hash. You can use the following command to find
+      # out the sha256, for example, with version 1.0.3:
+      # `nix-prefetch-github --rev v1.0.3 laamaa m8c`
+      #
+      # 2. NEW DEPENDENCIES:
+      # Make sure new dependencies are added. Runtime deps go to buildInputs and
+      # compile-time deps go to nativeBuildInputs. Use the nixpkgs manual for help
+      pname = "m8c";
+      version = "1.7.6";
+      m8c-package =
+        { stdenv
+        , gnumake
+        , pkg-config
+        , SDL2
+        , libserialport
+        , fetchFromGitHub
+        }:
+        stdenv.mkDerivation {
+          inherit pname version;
+
+          src = fetchFromGitHub {
+            owner = "laamaa";
+            repo = pname;
+            rev = "v${version}";
+            hash = "sha256:1b2wg8zmxisn1kc3wkfzcij1707pz560yq8v6rwjirr0dd27a3n2";
+          };
+
+          installFlags = [ "PREFIX=$(out)" ];
+          nativeBuildInputs = [ gnumake pkg-config ];
+          buildInputs = [ SDL2 libserialport ];
+        };
+      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f
+        (import nixpkgs { inherit system; })
+      );
+      treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs (_: {
+        projectRootFile = "flake.nix";
+        programs = {
+          clang-format.enable = false; # TODO(pope): Enable and format C code
+          deadnix.enable = true;
+          nixpkgs-fmt.enable = true;
+          statix.enable = true;
+        };
+      }));
+    in
+    {
+      packages = eachSystem (pkgs: rec {
+        m8c-stable = pkgs.callPackage m8c-package { };
+        m8c-dev = (pkgs.callPackage m8c-package { }).overrideAttrs (_oldAttrs: {
+          src = ./.;
+        });
+        default = m8c-stable;
+      });
+
+      overlays.default = final: _prev: {
+        inherit (self.packages.${final.system}) m8c-stable m8c-dev;
+      };
+
+      apps = eachSystem (pkgs: rec {
+        m8c = {
+          type = "app";
+          program = "${self.packages.${pkgs.system}.m8c-stable}/bin/m8c";
+        };
+        default = m8c;
+      });
+
+      devShells = eachSystem (pkgs: with pkgs; {
+        default = mkShell {
+          packages = [
+            nix-prefetch-github
+            treefmtEval.${system}.config.build.wrapper
+          ];
+          inputsFrom = [ self.packages.${system}.m8c-dev ];
+        };
+      });
+
+      formatter = eachSystem (pkgs: treefmtEval.${pkgs.system}.config.build.wrapper);
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,13 @@
-{ pkgs ? import <nixpkgs> {} }:
-
-with pkgs;
-
-mkShell {
-  packages = with pkgs; [ nix-prefetch-github ];
-  inputsFrom = [ (import ./default.nix {}).m8c-dev ];
-}
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  {
+    src = ./.;
+  }).shellNix


### PR DESCRIPTION
Flakes are a different way to specify a Nix project/configuration. It provides a few benefits over the existing solution:

  1. The exact versions of inputs are snapshot. This should mean that a build on one machine will use the exact same packages as the build on another.
  2. Flakes can be consumed by other Flakes. This would mean that folks could use this Flake as an import and then declaritively configure their `m8c` setup.
  3. While not used here now, this could make versioning easier. There wouldn't need to be a `fetchFromGitHub` step because someone could just use/run the app for that tagged branch. Ex: `nix run github:laamaa/m8c?ref=v1.7.7`

That said, this PR does rely on flake-compat to provide backward compatibility with `default.nix` and `shell.nix`. So a user could use `nix-shell` as before, or they could use `nix develop` (and potentially devenv in the future).