### PR TITLE
Allow user to specify alternate config file with --config flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ If the file does not exist, it will be created in one of these locations:
 * Linux: `/home/<username>/.local/share/m8c/config.ini`
 * MacOS: `/Users/<username>/Library/Application Support/m8c/config.ini`
 
+You can choose to load an alternate configuration with the `--config` command line option. Example:
+
+```
+m8c --config alternate_config.ini
+```
+
+This looks for a config file with the given name in the same directory as the default config. If you specify a config file that does not exist, a new default config file with the specified name will be created, which you can then edit.
+
 Enjoy making some nice music!
 
 -----------

--- a/src/config.c
+++ b/src/config.c
@@ -18,10 +18,14 @@ static int strcmpci(const char *a, const char *b) {
   }
 }
 
-config_params_s init_config() {
+config_params_s init_config(char *filename) {
   config_params_s c;
 
-  c.filename = "config.ini"; // default config file to load
+  if (filename == NULL) {
+    c.filename = "config.ini"; // default config file to load
+  } else {
+    c.filename = filename;
+  }
 
   c.init_fullscreen = 0; // default fullscreen state at load
   c.init_use_gpu = 1;    // default to use hardware acceleration

--- a/src/main.c
+++ b/src/main.c
@@ -49,8 +49,6 @@ int main(const int argc, char *argv[]) {
   // Initialize the config to defaults read in the params from the
   // configfile if present
   config_params_s conf = init_config(config_filename);
-
-  // TODO: take cli parameter to override default configfile location
   read_config(&conf);
 
   // allocate memory for serial buffer

--- a/src/main.c
+++ b/src/main.c
@@ -40,9 +40,15 @@ int main(const int argc, char *argv[]) {
     SDL_Log("Using preferred device %s.\n", preferred_device);
   }
 
+  char *config_filename = NULL;
+  if (argc == 3 && SDL_strcmp(argv[1], "--config") == 0) {
+    config_filename = argv[2];
+    SDL_Log("Using config file %s.\n", config_filename);
+  }
+
   // Initialize the config to defaults read in the params from the
   // configfile if present
-  config_params_s conf = init_config();
+  config_params_s conf = init_config(config_filename);
 
   // TODO: take cli parameter to override default configfile location
   read_config(&conf);


### PR DESCRIPTION
Use case: 

Sometimes I want to use my laptop keyboard to control M8. Other times I want to use an external keypad I've set up to mimic a hardware M8. This allows me to have two different configs and choose which one to use when I run m8c.

`./m8c` - runs with the default config, `config.ini`

`./m8c --config config-keypad.ini` - runs the alternate config specified.

Notes:

- The alternate confg(s) are expected to be in the same config path as the default one.
- If a user specifies a config that does not exist, it will be created with a default config, which they can then edit.