### PR TITLE
Update nixpkgs so that the SDL3 dependency can be found

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,16 +18,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721821769,
-        "narHash": "sha256-PhmkdTJs2SfqKzSyDB74rDKp1MH4mGk0pG/+WqrnGEw=",
+        "lastModified": 1756819007,
+        "narHash": "sha256-12V64nKG/O/guxSYnr5/nq1EfqwJCdD2+cIGmhz3nrE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0907b75146a0ccc1ec0d6c3db287ec287588ef6",
+        "rev": "aaff8c16d7fc04991cac6245bee1baa31f72b1e1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
@@ -31,7 +31,7 @@
         { stdenv
         , gnumake
         , pkg-config
-        , SDL3
+        , sdl3
         , libserialport
         , fetchFromGitHub
         }:
@@ -47,7 +47,7 @@
 
           installFlags = [ "PREFIX=$(out)" ];
           nativeBuildInputs = [ gnumake pkg-config ];
-          buildInputs = [ SDL3 libserialport ];
+          buildInputs = [ sdl3 libserialport ];
         };
       eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f
         (import nixpkgs { inherit system; })
@@ -86,6 +86,8 @@
       devShells = eachSystem (pkgs: with pkgs; {
         default = mkShell {
           packages = [
+            cmake
+            gnumake
             nix-prefetch-github
             treefmtEval.${system}.config.build.wrapper
           ];


### PR DESCRIPTION
This migrates to nixpkgs-unstable for always getting the latest dependencies (provided `nix flake update` is run). As a result, SDL3 can be found, though the dependency is spelled with lower-case instead of upper case.

The cmake package was added to the dev shell so that a MacOS build could also be tested with these changes.