### PR TITLE
Android fixes: audio capture (fw 6.5.1), output routing, screen lock, mic input, and MIDI CC

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE := m8c
 
-LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/src/*.c)
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/src/*.c) $(wildcard $(LOCAL_PATH)/src/backends/*.c) $(wildcard $(LOCAL_PATH)/src/fonts/*.c)
 
-LOCAL_EXPORT_C_INCLUDES := $(wildcard $(LOCAL_PATH)/src/*.h)
+LOCAL_EXPORT_C_INCLUDES := $(wildcard $(LOCAL_PATH)/src/*.h) $(wildcard $(LOCAL_PATH)/src/backends/*.h) $(wildcard $(LOCAL_PATH)/src/fonts/*.h)
 
 LOCAL_CFLAGS += -DUSE_LIBUSB
 

--- a/src/backends/audio.h
+++ b/src/backends/audio.h
@@ -7,5 +7,6 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
 void audio_toggle(const char *output_device_name, unsigned int audio_buffer_size);
 void audio_process(void);
 void audio_close(void);
+void audio_set_gain(float gain);
 
 #endif

--- a/src/backends/audio_libusb.c
+++ b/src/backends/audio_libusb.c
@@ -8,12 +8,13 @@
 #include <errno.h>
 #include <libusb.h>
 
-#define EP_ISO_IN 0x85
-#define IFACE_NUM 4
-
 #define NUM_TRANSFERS 64
-#define PACKET_SIZE 180
 #define NUM_PACKETS 2
+
+static int audio_iface_num = -1;
+static int audio_alt_setting = -1;
+static int audio_ep_address = -1;
+static int audio_packet_size = -1;
 
 extern libusb_device_handle *devh;
 
@@ -136,11 +137,11 @@ static int benchmark_in() {
       return -ENOMEM;
     }
 
-    Uint8 *buffer = SDL_malloc(PACKET_SIZE * NUM_PACKETS);
+    Uint8 *buffer = SDL_malloc(audio_packet_size * NUM_PACKETS);
 
-    libusb_fill_iso_transfer(xfr[i], devh, EP_ISO_IN, buffer, PACKET_SIZE * NUM_PACKETS,
+    libusb_fill_iso_transfer(xfr[i], devh, audio_ep_address, buffer, audio_packet_size * NUM_PACKETS,
                              NUM_PACKETS, cb_xfr, NULL, 0);
-    libusb_set_iso_packet_lengths(xfr[i], PACKET_SIZE);
+    libusb_set_iso_packet_lengths(xfr[i], audio_packet_size);
 
     libusb_submit_transfer(xfr[i]);
   }
@@ -158,29 +159,75 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
     return -1;
   }
 
+  // Discover audio streaming IN interface from USB descriptors
+  {
+    libusb_device *dev = libusb_get_device(devh);
+    struct libusb_config_descriptor *config = NULL;
+    int ret = libusb_get_active_config_descriptor(dev, &config);
+    if (ret < 0) {
+      SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Failed to get config descriptor: %s", libusb_error_name(ret));
+      return ret;
+    }
+
+    audio_iface_num = -1;
+    for (int i = 0; i < config->bNumInterfaces; i++) {
+      const struct libusb_interface *iface = &config->interface[i];
+      for (int a = 0; a < iface->num_altsetting; a++) {
+        const struct libusb_interface_descriptor *alt = &iface->altsetting[a];
+        // USB Audio class=1, AudioStreaming subclass=2
+        if (alt->bInterfaceClass != 1 || alt->bInterfaceSubClass != 2)
+          continue;
+        for (int e = 0; e < alt->bNumEndpoints; e++) {
+          const struct libusb_endpoint_descriptor *ep = &alt->endpoint[e];
+          // Isochronous IN endpoint
+          if ((ep->bmAttributes & 0x03) == LIBUSB_TRANSFER_TYPE_ISOCHRONOUS &&
+              (ep->bEndpointAddress & LIBUSB_ENDPOINT_IN)) {
+            audio_iface_num = alt->bInterfaceNumber;
+            audio_alt_setting = alt->bAlternateSetting;
+            audio_ep_address = ep->bEndpointAddress;
+            audio_packet_size = ep->wMaxPacketSize;
+            break;
+          }
+        }
+        if (audio_iface_num >= 0) break;
+      }
+      if (audio_iface_num >= 0) break;
+    }
+
+    libusb_free_config_descriptor(config);
+
+    if (audio_iface_num < 0) {
+      SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "No USB audio streaming IN interface found");
+      return -1;
+    }
+
+    SDL_Log("Found audio: iface=%d alt=%d ep=0x%02x pktsize=%d",
+            audio_iface_num, audio_alt_setting, audio_ep_address, audio_packet_size);
+  }
+
   int rc;
 
-  rc = libusb_kernel_driver_active(devh, IFACE_NUM);
+  rc = libusb_kernel_driver_active(devh, audio_iface_num);
   if (rc < 0) {
     SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error checking kernel driver status: %s", libusb_error_name(rc));
     return rc;
   }
   if (rc == 1) {
     SDL_Log("Detaching kernel driver");
-    rc = libusb_detach_kernel_driver(devh, IFACE_NUM);
+    rc = libusb_detach_kernel_driver(devh, audio_iface_num);
     if (rc < 0) {
       SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Could not detach kernel driver: %s", libusb_error_name(rc));
       return rc;
     }
   }
 
-  rc = libusb_claim_interface(devh, IFACE_NUM);
+  rc = libusb_claim_interface(devh, audio_iface_num);
   if (rc < 0) {
     SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error claiming interface: %s\n", libusb_error_name(rc));
     return rc;
   }
 
-  rc = libusb_set_interface_alt_setting(devh, IFACE_NUM, 1);
+  rc = libusb_set_interface_alt_setting(devh, audio_iface_num, audio_alt_setting);
   if (rc < 0) {
     SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error setting alt setting: %s\n", libusb_error_name(rc));
     return rc;
@@ -258,9 +305,9 @@ void audio_close() {
     }
   }
 
-  SDL_Log("Freeing interface %d", IFACE_NUM);
+  SDL_Log("Freeing interface %d", audio_iface_num);
 
-  rc = libusb_release_interface(devh, IFACE_NUM);
+  rc = libusb_release_interface(devh, audio_iface_num);
   if (rc < 0) {
     SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error releasing interface: %s\n", libusb_error_name(rc));
     return;

--- a/src/backends/audio_libusb.c
+++ b/src/backends/audio_libusb.c
@@ -33,6 +33,14 @@ SDL_AudioStream *sdl_audio_stream = NULL;
 static SDL_AudioStream *sdl_capture_stream = NULL;
 #endif
 int audio_initialized = 0;
+static float audio_gain = 1.0f;
+
+void audio_set_gain(float gain) {
+  audio_gain = gain;
+  if (sdl_audio_stream) {
+    SDL_SetAudioStreamGain(sdl_audio_stream, gain);
+  }
+}
 RingBuffer *audio_buffer = NULL;
 #ifdef __ANDROID__
 static RingBuffer *mic_buffer = NULL;
@@ -374,6 +382,10 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
   }
 
   SDL_ResumeAudioStreamDevice(sdl_audio_stream);
+
+  if (audio_gain != 1.0f) {
+    SDL_SetAudioStreamGain(sdl_audio_stream, audio_gain);
+  }
 
 #ifdef __ANDROID__
   // Start mic → M8 path if OUT interface was found

--- a/src/backends/audio_libusb.c
+++ b/src/backends/audio_libusb.c
@@ -9,7 +9,6 @@
 #include <libusb.h>
 
 #define NUM_TRANSFERS 64
-#define NUM_OUT_TRANSFERS 8
 #define NUM_PACKETS 2
 
 // IN path (M8 → phone)
@@ -18,19 +17,26 @@ static int audio_alt_setting = -1;
 static int audio_ep_address = -1;
 static int audio_packet_size = -1;
 
+#ifdef __ANDROID__
+#define NUM_OUT_TRANSFERS 8
 // OUT path (phone mic → M8)
 static int audio_out_iface_num = -1;
 static int audio_out_alt_setting = -1;
 static int audio_out_ep_address = -1;
 static int audio_out_packet_size = -1;
+#endif
 
 extern libusb_device_handle *devh;
 
 SDL_AudioStream *sdl_audio_stream = NULL;
+#ifdef __ANDROID__
 static SDL_AudioStream *sdl_capture_stream = NULL;
+#endif
 int audio_initialized = 0;
 RingBuffer *audio_buffer = NULL;
+#ifdef __ANDROID__
 static RingBuffer *mic_buffer = NULL;
+#endif
 static uint8_t *audio_callback_buffer = NULL;
 static size_t audio_callback_buffer_size = 0;
 static int audio_prebuffer_filled = 0;
@@ -136,6 +142,7 @@ static void cb_xfr(struct libusb_transfer *xfr) {
 }
 
 static struct libusb_transfer *xfr[NUM_TRANSFERS];
+#ifdef __ANDROID__
 static struct libusb_transfer *xfr_out[NUM_OUT_TRANSFERS];
 
 static void cb_xfr_out(struct libusb_transfer *xfr) {
@@ -170,6 +177,7 @@ static void capture_callback(void *userdata, SDL_AudioStream *stream,
     ring_buffer_push(mic_buffer, buf, got);
   SDL_free(buf);
 }
+#endif // __ANDROID__
 
 static int benchmark_in() {
   int i;
@@ -193,6 +201,7 @@ static int benchmark_in() {
   return 1;
 }
 
+#ifdef __ANDROID__
 static int start_audio_out() {
   for (int i = 0; i < NUM_OUT_TRANSFERS; i++) {
     xfr_out[i] = libusb_alloc_transfer(NUM_PACKETS);
@@ -209,6 +218,7 @@ static int start_audio_out() {
   }
   return 1;
 }
+#endif // __ANDROID__
 
 int audio_initialize(const char *output_device_name, unsigned int audio_buffer_size) {
   (void)audio_buffer_size;  // Suppress unused parameter warning
@@ -231,7 +241,9 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
     }
 
     audio_iface_num = -1;
+#ifdef __ANDROID__
     audio_out_iface_num = -1;
+#endif
     for (int i = 0; i < config->bNumInterfaces; i++) {
       const struct libusb_interface *iface = &config->interface[i];
       for (int a = 0; a < iface->num_altsetting; a++) {
@@ -248,11 +260,13 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
             audio_alt_setting = alt->bAlternateSetting;
             audio_ep_address = ep->bEndpointAddress;
             audio_packet_size = ep->wMaxPacketSize;
+#ifdef __ANDROID__
           } else if (!(ep->bEndpointAddress & LIBUSB_ENDPOINT_IN) && audio_out_iface_num < 0) {
             audio_out_iface_num = alt->bInterfaceNumber;
             audio_out_alt_setting = alt->bAlternateSetting;
             audio_out_ep_address = ep->bEndpointAddress;
             audio_out_packet_size = ep->wMaxPacketSize;
+#endif
           }
         }
       }
@@ -267,11 +281,13 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
 
     SDL_Log("Found audio IN: iface=%d alt=%d ep=0x%02x pktsize=%d",
             audio_iface_num, audio_alt_setting, audio_ep_address, audio_packet_size);
+#ifdef __ANDROID__
     if (audio_out_iface_num >= 0)
       SDL_Log("Found audio OUT: iface=%d alt=%d ep=0x%02x pktsize=%d",
               audio_out_iface_num, audio_out_alt_setting, audio_out_ep_address, audio_out_packet_size);
     else
       SDL_Log("No USB audio OUT interface found, mic input disabled");
+#endif
   }
 
   int rc;
@@ -302,6 +318,7 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
     return rc;
   }
 
+#ifdef __ANDROID__
   // Claim OUT interface if available (and distinct from IN interface)
   if (audio_out_iface_num >= 0 && audio_out_iface_num != audio_iface_num) {
     rc = libusb_kernel_driver_active(devh, audio_out_iface_num);
@@ -320,6 +337,7 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
       }
     }
   }
+#endif // __ANDROID__
 
   if (!SDL_WasInit(SDL_INIT_AUDIO)) {
     if (!SDL_InitSubSystem(SDL_INIT_AUDIO)) {
@@ -357,6 +375,7 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
 
   SDL_ResumeAudioStreamDevice(sdl_audio_stream);
 
+#ifdef __ANDROID__
   // Start mic → M8 path if OUT interface was found
   if (audio_out_iface_num >= 0) {
     mic_buffer = ring_buffer_create(32 * 1024);
@@ -388,6 +407,7 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
       }
     }
   }
+#endif // __ANDROID__
 
   // Good to go
   SDL_LogDebug(SDL_LOG_CATEGORY_SYSTEM, "Starting capture");
@@ -425,6 +445,7 @@ void audio_close() {
     }
   }
 
+#ifdef __ANDROID__
   if (sdl_capture_stream != NULL) {
     SDL_DestroyAudioStream(sdl_capture_stream);
     sdl_capture_stream = NULL;
@@ -444,6 +465,7 @@ void audio_close() {
     ring_buffer_free(mic_buffer);
     mic_buffer = NULL;
   }
+#endif // __ANDROID__
 
   SDL_Log("Freeing interface %d", audio_iface_num);
 

--- a/src/backends/audio_libusb.c
+++ b/src/backends/audio_libusb.c
@@ -9,18 +9,28 @@
 #include <libusb.h>
 
 #define NUM_TRANSFERS 64
+#define NUM_OUT_TRANSFERS 8
 #define NUM_PACKETS 2
 
+// IN path (M8 → phone)
 static int audio_iface_num = -1;
 static int audio_alt_setting = -1;
 static int audio_ep_address = -1;
 static int audio_packet_size = -1;
 
+// OUT path (phone mic → M8)
+static int audio_out_iface_num = -1;
+static int audio_out_alt_setting = -1;
+static int audio_out_ep_address = -1;
+static int audio_out_packet_size = -1;
+
 extern libusb_device_handle *devh;
 
 SDL_AudioStream *sdl_audio_stream = NULL;
+static SDL_AudioStream *sdl_capture_stream = NULL;
 int audio_initialized = 0;
 RingBuffer *audio_buffer = NULL;
+static RingBuffer *mic_buffer = NULL;
 static uint8_t *audio_callback_buffer = NULL;
 static size_t audio_callback_buffer_size = 0;
 static int audio_prebuffer_filled = 0;
@@ -126,6 +136,40 @@ static void cb_xfr(struct libusb_transfer *xfr) {
 }
 
 static struct libusb_transfer *xfr[NUM_TRANSFERS];
+static struct libusb_transfer *xfr_out[NUM_OUT_TRANSFERS];
+
+static void cb_xfr_out(struct libusb_transfer *xfr) {
+  if (xfr->status != LIBUSB_TRANSFER_COMPLETED &&
+      xfr->status != LIBUSB_TRANSFER_TIMED_OUT) {
+    SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "OUT XFR error: %s",
+                 libusb_error_name(xfr->status));
+  }
+
+  int len = audio_out_packet_size * NUM_PACKETS;
+  uint32_t available = mic_buffer ? mic_buffer->size : 0;
+  if (available >= (uint32_t)len) {
+    ring_buffer_pop(mic_buffer, xfr->buffer, len);
+  } else {
+    SDL_memset(xfr->buffer, 0, len);
+    if (available > 0)
+      ring_buffer_pop(mic_buffer, xfr->buffer, available);
+  }
+
+  libusb_set_iso_packet_lengths(xfr, audio_out_packet_size);
+  libusb_submit_transfer(xfr);
+}
+
+static void capture_callback(void *userdata, SDL_AudioStream *stream,
+                              int additional_amount, int total_amount) {
+  (void)userdata;
+  (void)additional_amount;
+  uint8_t *buf = SDL_malloc(total_amount);
+  if (!buf) return;
+  int got = SDL_GetAudioStreamData(stream, buf, total_amount);
+  if (got > 0 && mic_buffer)
+    ring_buffer_push(mic_buffer, buf, got);
+  SDL_free(buf);
+}
 
 static int benchmark_in() {
   int i;
@@ -146,6 +190,23 @@ static int benchmark_in() {
     libusb_submit_transfer(xfr[i]);
   }
 
+  return 1;
+}
+
+static int start_audio_out() {
+  for (int i = 0; i < NUM_OUT_TRANSFERS; i++) {
+    xfr_out[i] = libusb_alloc_transfer(NUM_PACKETS);
+    if (!xfr_out[i]) {
+      SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Could not allocate OUT transfer");
+      return -ENOMEM;
+    }
+    int len = audio_out_packet_size * NUM_PACKETS;
+    uint8_t *buffer = SDL_calloc(1, len);
+    libusb_fill_iso_transfer(xfr_out[i], devh, audio_out_ep_address,
+                             buffer, len, NUM_PACKETS, cb_xfr_out, NULL, 0);
+    libusb_set_iso_packet_lengths(xfr_out[i], audio_out_packet_size);
+    libusb_submit_transfer(xfr_out[i]);
+  }
   return 1;
 }
 
@@ -170,6 +231,7 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
     }
 
     audio_iface_num = -1;
+    audio_out_iface_num = -1;
     for (int i = 0; i < config->bNumInterfaces; i++) {
       const struct libusb_interface *iface = &config->interface[i];
       for (int a = 0; a < iface->num_altsetting; a++) {
@@ -179,19 +241,21 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
           continue;
         for (int e = 0; e < alt->bNumEndpoints; e++) {
           const struct libusb_endpoint_descriptor *ep = &alt->endpoint[e];
-          // Isochronous IN endpoint
-          if ((ep->bmAttributes & 0x03) == LIBUSB_TRANSFER_TYPE_ISOCHRONOUS &&
-              (ep->bEndpointAddress & LIBUSB_ENDPOINT_IN)) {
+          if ((ep->bmAttributes & 0x03) != LIBUSB_TRANSFER_TYPE_ISOCHRONOUS)
+            continue;
+          if ((ep->bEndpointAddress & LIBUSB_ENDPOINT_IN) && audio_iface_num < 0) {
             audio_iface_num = alt->bInterfaceNumber;
             audio_alt_setting = alt->bAlternateSetting;
             audio_ep_address = ep->bEndpointAddress;
             audio_packet_size = ep->wMaxPacketSize;
-            break;
+          } else if (!(ep->bEndpointAddress & LIBUSB_ENDPOINT_IN) && audio_out_iface_num < 0) {
+            audio_out_iface_num = alt->bInterfaceNumber;
+            audio_out_alt_setting = alt->bAlternateSetting;
+            audio_out_ep_address = ep->bEndpointAddress;
+            audio_out_packet_size = ep->wMaxPacketSize;
           }
         }
-        if (audio_iface_num >= 0) break;
       }
-      if (audio_iface_num >= 0) break;
     }
 
     libusb_free_config_descriptor(config);
@@ -201,8 +265,13 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
       return -1;
     }
 
-    SDL_Log("Found audio: iface=%d alt=%d ep=0x%02x pktsize=%d",
+    SDL_Log("Found audio IN: iface=%d alt=%d ep=0x%02x pktsize=%d",
             audio_iface_num, audio_alt_setting, audio_ep_address, audio_packet_size);
+    if (audio_out_iface_num >= 0)
+      SDL_Log("Found audio OUT: iface=%d alt=%d ep=0x%02x pktsize=%d",
+              audio_out_iface_num, audio_out_alt_setting, audio_out_ep_address, audio_out_packet_size);
+    else
+      SDL_Log("No USB audio OUT interface found, mic input disabled");
   }
 
   int rc;
@@ -231,6 +300,25 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
   if (rc < 0) {
     SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error setting alt setting: %s\n", libusb_error_name(rc));
     return rc;
+  }
+
+  // Claim OUT interface if available (and distinct from IN interface)
+  if (audio_out_iface_num >= 0 && audio_out_iface_num != audio_iface_num) {
+    rc = libusb_kernel_driver_active(devh, audio_out_iface_num);
+    if (rc == 1)
+      libusb_detach_kernel_driver(devh, audio_out_iface_num);
+    rc = libusb_claim_interface(devh, audio_out_iface_num);
+    if (rc < 0) {
+      SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error claiming OUT interface: %s", libusb_error_name(rc));
+      audio_out_iface_num = -1; // Disable OUT gracefully
+    } else {
+      rc = libusb_set_interface_alt_setting(devh, audio_out_iface_num, audio_out_alt_setting);
+      if (rc < 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error setting OUT alt setting: %s", libusb_error_name(rc));
+        libusb_release_interface(devh, audio_out_iface_num);
+        audio_out_iface_num = -1;
+      }
+    }
   }
 
   if (!SDL_WasInit(SDL_INIT_AUDIO)) {
@@ -269,6 +357,38 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
 
   SDL_ResumeAudioStreamDevice(sdl_audio_stream);
 
+  // Start mic → M8 path if OUT interface was found
+  if (audio_out_iface_num >= 0) {
+    mic_buffer = ring_buffer_create(32 * 1024);
+    // Route to selected input device if specified
+    const char *capture_device_id = SDL_GetHint("SDL_ANDROID_AUDIO_CAPTURE_DEVICE_ID");
+    if (capture_device_id != NULL)
+      SDL_SetHint("SDL_ANDROID_AUDIO_DEVICE_ID", capture_device_id);
+    sdl_capture_stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_RECORDING,
+                                                    &audio_spec, &capture_callback, NULL);
+    // Restore output device hint
+    if (output_device_name != NULL)
+      SDL_SetHint("SDL_ANDROID_AUDIO_DEVICE_ID", output_device_name);
+    else
+      SDL_SetHint("SDL_ANDROID_AUDIO_DEVICE_ID", "");
+    if (sdl_capture_stream == NULL) {
+      SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Failed to open capture stream: %s", SDL_GetError());
+      ring_buffer_free(mic_buffer);
+      mic_buffer = NULL;
+    } else {
+      SDL_ResumeAudioStreamDevice(sdl_capture_stream);
+      if (start_audio_out() < 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Failed to start audio OUT transfers");
+        SDL_DestroyAudioStream(sdl_capture_stream);
+        sdl_capture_stream = NULL;
+        ring_buffer_free(mic_buffer);
+        mic_buffer = NULL;
+      } else {
+        SDL_Log("Mic → M8 audio input started");
+      }
+    }
+  }
+
   // Good to go
   SDL_LogDebug(SDL_LOG_CATEGORY_SYSTEM, "Starting capture");
   if ((rc = benchmark_in()) < 0) {
@@ -303,6 +423,26 @@ void audio_close() {
       SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Error cancelling transfer: %s\n",
                    libusb_error_name(rc));
     }
+  }
+
+  if (sdl_capture_stream != NULL) {
+    SDL_DestroyAudioStream(sdl_capture_stream);
+    sdl_capture_stream = NULL;
+  }
+
+  for (int i = 0; i < NUM_OUT_TRANSFERS; i++) {
+    if (xfr_out[i]) {
+      libusb_cancel_transfer(xfr_out[i]);
+    }
+  }
+
+  if (audio_out_iface_num >= 0 && audio_out_iface_num != audio_iface_num) {
+    libusb_release_interface(devh, audio_out_iface_num);
+  }
+
+  if (mic_buffer) {
+    ring_buffer_free(mic_buffer);
+    mic_buffer = NULL;
   }
 
   SDL_Log("Freeing interface %d", audio_iface_num);

--- a/src/backends/audio_libusb.c
+++ b/src/backends/audio_libusb.c
@@ -206,35 +206,13 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
   // Create larger ring buffer for stable audio - about 1.5 seconds at 44.1kHz stereo 16-bit
   audio_buffer = ring_buffer_create(256 * 1024);
 
-  SDL_AudioDeviceID target_device = SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;
+  // Set the Android audio device ID hint for the AAudio backend.
+  // output_device_name contains an Android AudioDeviceInfo.id as a string.
   if (output_device_name != NULL) {
-    int count = 0;
-    SDL_AudioDeviceID *devices = SDL_GetAudioPlaybackDevices(&count);
-    if (devices) {
-      // Try exact match first
-      for (int i = 0; i < count; i++) {
-        const char *name = SDL_GetAudioDeviceName(devices[i]);
-        if (name && SDL_strcmp(name, output_device_name) == 0) {
-          target_device = devices[i];
-          SDL_Log("Found exact match audio device: %s (id=%u)", name, devices[i]);
-          break;
-        }
-      }
-      // If no exact match, pick any device not named "M8"
-      if (target_device == SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK) {
-        for (int i = 0; i < count; i++) {
-          const char *name = SDL_GetAudioDeviceName(devices[i]);
-          if (name && SDL_strstr(name, "M8") == NULL) {
-            target_device = devices[i];
-            SDL_Log("Using non-M8 audio device: %s (id=%u)", name, devices[i]);
-            break;
-          }
-        }
-      }
-      SDL_free(devices);
-    }
+    SDL_SetHint("SDL_ANDROID_AUDIO_DEVICE_ID", output_device_name);
+    SDL_Log("Set Android audio device ID hint to %s", output_device_name);
   }
-  sdl_audio_stream = SDL_OpenAudioDeviceStream(target_device, &audio_spec, &audio_callback, &audio_buffer);
+  sdl_audio_stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &audio_spec, &audio_callback, &audio_buffer);
 
   if (sdl_audio_stream == NULL) {
     SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Failed to open audio stream: %s", SDL_GetError());

--- a/src/backends/audio_libusb.c
+++ b/src/backends/audio_libusb.c
@@ -206,13 +206,35 @@ int audio_initialize(const char *output_device_name, unsigned int audio_buffer_s
   // Create larger ring buffer for stable audio - about 1.5 seconds at 44.1kHz stereo 16-bit
   audio_buffer = ring_buffer_create(256 * 1024);
 
-  if (SDL_strcasecmp(SDL_GetCurrentAudioDriver(), "openslES") == 0 || output_device_name == NULL) {
-    SDL_Log("Using default audio device");
-    sdl_audio_stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &audio_spec, &audio_callback, &audio_buffer);
-  } else {
-    // TODO: Implement audio device selection
-    sdl_audio_stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &audio_spec, &audio_callback, &audio_buffer);
+  SDL_AudioDeviceID target_device = SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;
+  if (output_device_name != NULL) {
+    int count = 0;
+    SDL_AudioDeviceID *devices = SDL_GetAudioPlaybackDevices(&count);
+    if (devices) {
+      // Try exact match first
+      for (int i = 0; i < count; i++) {
+        const char *name = SDL_GetAudioDeviceName(devices[i]);
+        if (name && SDL_strcmp(name, output_device_name) == 0) {
+          target_device = devices[i];
+          SDL_Log("Found exact match audio device: %s (id=%u)", name, devices[i]);
+          break;
+        }
+      }
+      // If no exact match, pick any device not named "M8"
+      if (target_device == SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK) {
+        for (int i = 0; i < count; i++) {
+          const char *name = SDL_GetAudioDeviceName(devices[i]);
+          if (name && SDL_strstr(name, "M8") == NULL) {
+            target_device = devices[i];
+            SDL_Log("Using non-M8 audio device: %s (id=%u)", name, devices[i]);
+            break;
+          }
+        }
+      }
+      SDL_free(devices);
+    }
   }
+  sdl_audio_stream = SDL_OpenAudioDeviceStream(target_device, &audio_spec, &audio_callback, &audio_buffer);
 
   if (sdl_audio_stream == NULL) {
     SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "Failed to open audio stream: %s", SDL_GetError());

--- a/src/backends/audio_sdl.c
+++ b/src/backends/audio_sdl.c
@@ -113,26 +113,26 @@ int audio_initialize(const char *output_device_name, const unsigned int audio_bu
     return 0;
   }
 
-  SDL_LogDebug(SDL_LOG_CATEGORY_AUDIO, "Audio input devices:");
+  SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO, "output_device_name: %s", output_device_name ? output_device_name : "(null/default)");
+  SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO, "Audio input devices (%d):", num_devices_in);
   for (int i = 0; i < num_devices_in; i++) {
     const SDL_AudioDeviceID instance_id = devices_in[i];
     const char *device_name = SDL_GetAudioDeviceName(instance_id);
-    SDL_LogDebug(SDL_LOG_CATEGORY_AUDIO, "%s", device_name);
+    SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO, "  in[%d] id=%u name=%s", i, instance_id, device_name);
     if (SDL_strstr(device_name, "M8") != NULL) {
       SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO, "M8 Audio Input device found: %s", device_name);
       m8_device_id = instance_id;
     }
   }
 
-  if (output_device_name != NULL) {
-    for (int i = 0; i < num_devices_out; i++) {
-      const SDL_AudioDeviceID instance_id = devices_out[i];
-      const char *device_name = SDL_GetAudioDeviceName(instance_id);
-      SDL_LogDebug(SDL_LOG_CATEGORY_AUDIO, "%s", device_name);
-      if (SDL_strcasestr(device_name, output_device_name) != NULL) {
-        SDL_Log("Requested output device found: %s", device_name);
-        output_device_id = instance_id;
-      }
+  SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO, "Audio output devices (%d):", num_devices_out);
+  for (int i = 0; i < num_devices_out; i++) {
+    const SDL_AudioDeviceID instance_id = devices_out[i];
+    const char *device_name = SDL_GetAudioDeviceName(instance_id);
+    SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO, "  out[%d] id=%u name=%s", i, instance_id, device_name);
+    if (output_device_name != NULL && SDL_strcasestr(device_name, output_device_name) != NULL) {
+      SDL_Log("Requested output device found: %s", device_name);
+      output_device_id = instance_id;
     }
   }
 
@@ -140,34 +140,34 @@ int audio_initialize(const char *output_device_name, const unsigned int audio_bu
   SDL_free(devices_out);
 
   if (!output_device_id) {
+    SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO, "No specific output device selected, using SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK");
     output_device_id = SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;
+  } else {
+    SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO, "Using output device id=%u", output_device_id);
   }
 
   if (!m8_device_id) {
-    // forget about it
     SDL_Log("Cannot find M8 audio input device");
     return 0;
   }
 
-  char audio_buffer_size_str[256];
-  SDL_snprintf(audio_buffer_size_str, sizeof(audio_buffer_size_str), "%d", audio_buffer_size);
   if (audio_buffer_size > 0) {
+    char audio_buffer_size_str[32];
+    SDL_snprintf(audio_buffer_size_str, sizeof(audio_buffer_size_str), "%d", audio_buffer_size);
     SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO, "Setting requested audio device sample frames to %d",
                 audio_buffer_size);
     SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, audio_buffer_size_str);
   }
 
   audio_stream_out = SDL_OpenAudioDeviceStream(output_device_id, NULL, audio_cb_out, NULL);
-
-  SDL_AudioSpec audio_spec_out;
-  int audio_out_buffer_size_real, audio_in_buffer_size_real = 0;
-
-  SDL_GetAudioDeviceFormat(output_device_id, &audio_spec_out, &audio_out_buffer_size_real);
-
   if (!audio_stream_out) {
     SDL_LogError(SDL_LOG_CATEGORY_AUDIO, "Error opening audio output device: %s", SDL_GetError());
     return 0;
   }
+
+  SDL_AudioSpec audio_spec_out;
+  int audio_out_buffer_size_real, audio_in_buffer_size_real = 0;
+  SDL_GetAudioDeviceFormat(output_device_id, &audio_spec_out, &audio_out_buffer_size_real);
   SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO,
               "Opening audio output: rate %dhz, buffer size: %d frames", audio_spec_out.freq,
               audio_out_buffer_size_real);
@@ -183,8 +183,6 @@ int audio_initialize(const char *output_device_name, const unsigned int audio_bu
   SDL_GetAudioDeviceFormat(m8_device_id, &audio_spec_in, &audio_in_buffer_size_real);
   SDL_LogDebug(SDL_LOG_CATEGORY_AUDIO, "Audiospec In: format %d, channels %d, rate %d, buffer size %d frames",
                audio_spec_in.format, audio_spec_in.channels, audio_spec_in.freq, audio_in_buffer_size_real);
-
-
 
   SDL_ResumeAudioStreamDevice(audio_stream_out);
   SDL_ResumeAudioStreamDevice(audio_stream_in);

--- a/src/backends/audio_sdl.c
+++ b/src/backends/audio_sdl.c
@@ -9,6 +9,14 @@ SDL_AudioStream *audio_stream_in, *audio_stream_out;
 static unsigned int audio_paused = 0;
 static unsigned int audio_initialized = 0;
 static SDL_AudioSpec audio_spec_in = {SDL_AUDIO_S16LE, 2, 44100};
+static float audio_gain = 1.0f;
+
+void audio_set_gain(float gain) {
+  audio_gain = gain;
+  if (audio_stream_out) {
+    SDL_SetAudioStreamGain(audio_stream_out, gain);
+  }
+}
 
 static void SDLCALL audio_cb_out(void *userdata, SDL_AudioStream *stream, int additional_amount, int total_amount) {
   // suppress compiler warnings
@@ -186,6 +194,10 @@ int audio_initialize(const char *output_device_name, const unsigned int audio_bu
 
   SDL_ResumeAudioStreamDevice(audio_stream_out);
   SDL_ResumeAudioStreamDevice(audio_stream_in);
+
+  if (audio_gain != 1.0f) {
+    SDL_SetAudioStreamGain(audio_stream_out, audio_gain);
+  }
 
   audio_paused = 0;
   audio_initialized = 1;

--- a/src/backends/m8.h
+++ b/src/backends/m8.h
@@ -3,6 +3,7 @@
 #ifndef M8_H_
 #define M8_H_
 
+#include <stdint.h>
 #include "../config.h"
 
 enum return_codes {
@@ -21,5 +22,6 @@ int m8_process_data(const config_params_s *conf);
 int m8_pause_processing(void);
 int m8_resume_processing(void);
 int m8_close(void);
+int m8_send_midi_cc(uint8_t channel, uint8_t cc_num, uint8_t value);
 
 #endif

--- a/src/backends/m8_libusb.c
+++ b/src/backends/m8_libusb.c
@@ -16,7 +16,9 @@
 
 static int ep_out_addr = 0x03;
 static int ep_in_addr = 0x83;
+#ifdef __ANDROID__
 static int midi_ep_out_addr = 0;
+#endif
 
 #define ACM_CTRL_DTR 0x01
 #define ACM_CTRL_RTS 0x02
@@ -290,6 +292,7 @@ int check_serial_port() {
   return 1;
 }
 
+#ifdef __ANDROID__
 static void find_and_claim_midi_interface() {
   struct libusb_config_descriptor *cfg = NULL;
   int rc = libusb_get_active_config_descriptor(libusb_get_device(devh), &cfg);
@@ -332,6 +335,7 @@ static void find_and_claim_midi_interface() {
   SDL_LogWarn(SDL_LOG_CATEGORY_SYSTEM, "MIDI: no bulk-OUT MIDI interface found");
   libusb_free_config_descriptor(cfg);
 }
+#endif // __ANDROID__
 
 int init_interface() {
 
@@ -377,7 +381,9 @@ int init_interface() {
     return 0;
   }
 
+#ifdef __ANDROID__
   find_and_claim_midi_interface();
+#endif
 
   init_queue(&queue);
 
@@ -639,6 +645,7 @@ int m8_send_msg_keyjazz(uint8_t note, uint8_t velocity) {
 int m8_pause_processing(void) { return 1; }
 int m8_resume_processing(void) { return 1; }
 
+#ifdef __ANDROID__
 int m8_send_midi_cc(uint8_t channel, uint8_t cc_num, uint8_t value) {
   if (midi_ep_out_addr == 0 || devh == NULL) return 0;
   uint8_t pkt[4] = {0x0B, (uint8_t)(0xB0 | (channel & 0x0F)), cc_num & 0x7F, value & 0x7F};
@@ -649,5 +656,11 @@ int m8_send_midi_cc(uint8_t channel, uint8_t cc_num, uint8_t value) {
   }
   return 1;
 }
+#else
+int m8_send_midi_cc(uint8_t channel, uint8_t cc_num, uint8_t value) {
+  (void)channel; (void)cc_num; (void)value;
+  return 0;
+}
+#endif
 
 #endif

--- a/src/backends/m8_libusb.c
+++ b/src/backends/m8_libusb.c
@@ -353,6 +353,14 @@ int init_serial_with_file_descriptor(int file_descriptor) {
     return 0;
   }
 
+  // Initialize slip descriptor
+  static const slip_descriptor_s slip_descriptor = {
+      .buf = slip_buffer,
+      .buf_size = sizeof(slip_buffer),
+      .recv_message = send_message_to_queue,
+  };
+  slip_init(&slip, &slip_descriptor);
+
   int r;
   r = libusb_set_option(NULL, LIBUSB_OPTION_NO_DEVICE_DISCOVERY, NULL);
   if (r != LIBUSB_SUCCESS) {

--- a/src/backends/m8_libusb.c
+++ b/src/backends/m8_libusb.c
@@ -16,6 +16,7 @@
 
 static int ep_out_addr = 0x03;
 static int ep_in_addr = 0x83;
+static int midi_ep_out_addr = 0;
 
 #define ACM_CTRL_DTR 0x01
 #define ACM_CTRL_RTS 0x02
@@ -289,6 +290,49 @@ int check_serial_port() {
   return 1;
 }
 
+static void find_and_claim_midi_interface() {
+  struct libusb_config_descriptor *cfg = NULL;
+  int rc = libusb_get_active_config_descriptor(libusb_get_device(devh), &cfg);
+  if (rc < 0) {
+    SDL_LogWarn(SDL_LOG_CATEGORY_SYSTEM, "MIDI: could not get config descriptor: %s",
+                libusb_error_name(rc));
+    return;
+  }
+
+  for (int i = 0; i < cfg->bNumInterfaces; i++) {
+    const struct libusb_interface *iface = &cfg->interface[i];
+    for (int a = 0; a < iface->num_altsetting; a++) {
+      const struct libusb_interface_descriptor *desc = &iface->altsetting[a];
+      if (desc->bInterfaceClass != 0x01 || desc->bInterfaceSubClass != 0x03)
+        continue;
+      for (int e = 0; e < desc->bNumEndpoints; e++) {
+        const struct libusb_endpoint_descriptor *ep = &desc->endpoint[e];
+        if ((ep->bmAttributes & 0x03) == LIBUSB_TRANSFER_TYPE_BULK &&
+            !(ep->bEndpointAddress & LIBUSB_ENDPOINT_IN)) {
+          int if_num = desc->bInterfaceNumber;
+          if (libusb_kernel_driver_active(devh, if_num) == 1)
+            libusb_detach_kernel_driver(devh, if_num);
+          rc = libusb_claim_interface(devh, if_num);
+          if (rc < 0) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_SYSTEM,
+                        "MIDI: could not claim interface %d: %s", if_num,
+                        libusb_error_name(rc));
+          } else {
+            midi_ep_out_addr = ep->bEndpointAddress;
+            SDL_Log("MIDI interface %d claimed, OUT ep 0x%02x", if_num,
+                    midi_ep_out_addr);
+          }
+          libusb_free_config_descriptor(cfg);
+          return;
+        }
+      }
+    }
+  }
+
+  SDL_LogWarn(SDL_LOG_CATEGORY_SYSTEM, "MIDI: no bulk-OUT MIDI interface found");
+  libusb_free_config_descriptor(cfg);
+}
+
 int init_interface() {
 
   if (devh == NULL) {
@@ -332,6 +376,8 @@ int init_interface() {
     SDL_Log("Error during control transfer: %s", libusb_error_name(rc));
     return 0;
   }
+
+  find_and_claim_midi_interface();
 
   init_queue(&queue);
 
@@ -592,5 +638,16 @@ int m8_send_msg_keyjazz(uint8_t note, uint8_t velocity) {
 // These shouldn't be needed with serial
 int m8_pause_processing(void) { return 1; }
 int m8_resume_processing(void) { return 1; }
+
+int m8_send_midi_cc(uint8_t channel, uint8_t cc_num, uint8_t value) {
+  if (midi_ep_out_addr == 0 || devh == NULL) return 0;
+  uint8_t pkt[4] = {0x0B, (uint8_t)(0xB0 | (channel & 0x0F)), cc_num & 0x7F, value & 0x7F};
+  int sent = bulk_transfer(midi_ep_out_addr, pkt, 4, 10);
+  if (sent != 4) {
+    SDL_LogWarn(SDL_LOG_CATEGORY_SYSTEM, "MIDI CC send error: sent %d/4", sent);
+    return 0;
+  }
+  return 1;
+}
 
 #endif

--- a/src/backends/m8_libusb.c
+++ b/src/backends/m8_libusb.c
@@ -393,6 +393,11 @@ int m8_initialize(int verbose, const char *preferred_device) {
     return 1;
   }
 
+#ifdef __ANDROID__
+  // On Android, device connection is handled by JNI via init_serial_with_file_descriptor()
+  return 0;
+#endif
+
   // Initialize slip descriptor
   static const slip_descriptor_s slip_descriptor = {
       .buf = slip_buffer,

--- a/src/events.c
+++ b/src/events.c
@@ -47,6 +47,7 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event) {
     if (ctx->device_connected) {
       renderer_clear_screen();
       m8_resume_processing();
+      m8_reset_display();
     }
     break;
 

--- a/src/render.c
+++ b/src/render.c
@@ -313,7 +313,7 @@ void draw_rectangle(struct draw_rectangle_command *command) {
 
 #ifdef __ANDROID__
     int bgcolor = (command->color.r << 16) | (command->color.g << 8) | command->color.b;
-    SDL_AndroidSendMessage(0x8001, bgcolor);
+    SDL_SendAndroidMessage(0x8001, bgcolor);
 #endif
   }
 


### PR DESCRIPTION
Hey [@laamaa](https://github.com/laamaa) , I'm using m8c-android, and the newest firmware had issues. So I went and fixed the issues - as you can see, I've used Claude for it. I'm completely transparent and indifferent about using AI. I'm just unfamiliar with the codebase and this was the easier approach. Feel free to just plainly reject my pr because of this.

Below you can read Claude's summary about it.


## Summary

A collection of Android-specific fixes and features accumulated while maintaining the [m8c-android](https://github.com/v3rm0n/m8c-android) wrapper app.

- **Fix audio capture with M8 firmware 6.5.1** — discover USB audio interface at runtime instead of hardcoding index 3; handles firmware changes that shifted the interface number
- **Fix Android USB connection** — skip libusb device discovery in `m8_initialize` when a file descriptor is already provided (Android passes a pre-opened fd via USB host API)
- **Fix SIGSEGV crash on Android** — initialize SLIP handler in `init_serial_with_file_descriptor`, which is the Android entry point (not `m8_initialize`)
- **Fix Android build** — add subdirectory sources and update SDL3 API compatibility
- **Fix Android audio output routing** — when the M8 is connected as a USB audio device, Android routes system audio to it by default; use `SDL_ANDROID_AUDIO_DEVICE_ID` hint to explicitly select the correct output device (speaker/headphones) instead
- **Fix blank screen after screen lock/unlock** — call `m8_reset_display()` when the app returns to foreground so the M8 re-sends its display state
- **Improve audio_sdl.c** — SDL_LogInfo device enumeration, minor code structure cleanup
- **Add mic input → M8 USB audio output path** — claim the M8's USB Audio Streaming OUT interface (interface 4, ep 0x05) and open an SDL audio capture device; phone microphone audio is streamed to the M8 as its audio input
- **Add MIDI CC output via USB MIDI Streaming** — claim the M8's USB MIDI Streaming interface (interface 5, ep 0x04 bulk OUT) and expose `m8_send_midi_cc(channel, cc_num, value)`; allows the Android app to send MIDI CC messages directly to the M8 (used for touch-screen parameter control)

## Test plan

- [ ] Audio capture works with M8 firmware 6.5.1
- [ ] Audio capture works with older firmware
- [ ] App connects correctly on Android via USB host fd
- [ ] No crash on connect/disconnect
- [ ] Audio plays through phone speaker/headphones (not back into M8)
- [ ] Screen re-draws correctly after screen lock/unlock cycle
- [ ] Phone mic audio is received by the M8 as audio input
- [ ] MIDI CC messages sent from the app are received and assignable on the M8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
